### PR TITLE
feat(backend): Return structured compile metadata and better error de…

### DIFF
--- a/backend/src/routes/compile.js
+++ b/backend/src/routes/compile.js
@@ -65,25 +65,37 @@ lto = true
         await cleanUp();
         return res.status(500).json({ 
           error: "Compilation failed", 
-          details: stderr || err.message 
+          status: "error",
+          details: stderr || err.message,
+          logs: stderr ? stderr.split('\n').filter(l => l.trim()) : []
         });
       }
 
       // Check if wasm exists
       const wasmPath = path.join(tempDir, "target", "wasm32-unknown-unknown", "release", "soroban_contract.wasm");
       try {
-        await fs.access(wasmPath);
+        const fileStats = await fs.stat(wasmPath);
         // It's built successfully
         await cleanUp();
         return res.json({ 
           success: true, 
+          status: "success",
           message: "Contract compiled successfully",
-          logs: stdout || "Build completed.",
-          // In a full implementation, you'd store the WASM or return its base64
+          logs: (stdout + (stderr ? "\n" + stderr : "")).split('\n').filter(l => l.trim()),
+          artifact: {
+            name: "soroban_contract.wasm",
+            sizeBytes: fileStats.size,
+            createdAt: fileStats.birthtime
+          }
         });
       } catch (e) {
         await cleanUp();
-        return res.status(500).json({ error: "WASM file not generated", details: stderr });
+        return res.status(500).json({ 
+          error: "WASM file not generated", 
+          status: "error",
+          details: stderr || e.message,
+          logs: stderr ? stderr.split('\n').filter(l => l.trim()) : []
+        });
       }
     });
 


### PR DESCRIPTION
PR #12 [Backend] Return Structured Compile Metadata and Better Error Details 
Description
This PR improves the response payloads for the compile route (/api/compile), making it much easier for the frontend to render meaningful logs and metadata. This is a targeted enhancement without altering the core compilation flow.

Changes Included
Richer Compile Metadata: Enhanced the success payload to include a targeted artifact object outlining sizeBytes and createdAt retrieved reliably via fs.stat().
Improved Failure Rendering: Standardized formatting for failure payloads, injecting a clear status: "error" label alongside a dedicated logs array correctly parsed by splitting the compilation stderr, making debugging from the browser instantly easier.
Preserved Core Flow: All interactions with cargo and temporary directory build steps and cleanups have been preserved.
Testing
Run the backend service and execute POST on /api/compile supplying rust code.
Validation should confirm the returned object features nested logs arrays instead of contiguous standard-out strings.
Closes #12 