### PR TITLE
Add hello world Soroban contract example

### DIFF
--- a/contracts/hello-world/Cargo.toml
+++ b/contracts/hello-world/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "hello-world"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = "20.0.0"
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/hello-world/README.md
+++ b/contracts/hello-world/README.md
@@ -1,0 +1,20 @@
+# Hello World Soroban Contract
+
+This folder contains a minimal Soroban contract example for the playground.
+
+## What it does
+
+The contract exposes one function:
+
+- `hello() -> String`: returns `"Hello, Soroban!"`
+
+## Files
+
+- `Cargo.toml`: Rust package configuration for building the contract to WASM.
+- `src/lib.rs`: the contract implementation.
+
+## Build
+
+```bash
+cargo build --target wasm32-unknown-unknown --release
+```

--- a/contracts/hello-world/src/lib.rs
+++ b/contracts/hello-world/src/lib.rs
@@ -1,0 +1,13 @@
+#![no_std]
+
+use soroban_sdk::{contract, contractimpl, String};
+
+#[contract]
+pub struct HelloWorldContract;
+
+#[contractimpl]
+impl HelloWorldContract {
+    pub fn hello() -> String {
+        String::from_str("Hello, Soroban!")
+    }
+}


### PR DESCRIPTION
This pull request introduces a new minimal "Hello World" contract for Soroban, including all necessary files and documentation. The contract provides a simple example function that returns a greeting string, and includes build instructions and configuration for compiling to WebAssembly.

New Soroban contract implementation:

* Added a new Rust contract in `src/lib.rs` that exposes a `hello()` function returning `"Hello, Soroban!"`.

Project setup and documentation:

* Added `Cargo.toml` to configure the Rust package, dependencies, and optimize for WASM builds.
* Added a `README.md` with an overview, usage, file descriptions, and build instructions for the contract.

Closes #18 