### PR TITLE
Contract readme

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,26 +1,27 @@
 # Contract Examples
 
-This folder contains small Soroban contract examples for the playground.
+This folder is the home for small Soroban contract examples used by the playground.
 
-The goal is to give contributors and new users a simple place to find contracts they can read, build, and reuse while testing the project locally.
+The goal is to give contributors a simple place to add contracts that are easy to read, build locally, and reuse while testing the project.
 
-## What belongs here
+## Purpose
 
-Each subfolder in `contracts/` should contain one self-contained example contract.
+Each directory inside `contracts/` should be one self-contained contract example.
 
-Examples should stay:
+Examples in this area should be:
 
-- Small and easy to understand
-- Focused on one idea or feature
+- Small and beginner-friendly
+- Focused on one contract idea or feature
+- Independent from other examples
 - Ready to build locally
 
 Current example:
 
-- `hello-world/`: a minimal Soroban contract with a short README
+- `hello-world/`: a minimal Soroban contract with its own README
 
 ## Recommended structure
 
-Add each new example in its own directory:
+Create a new directory for each example:
 
 ```text
 contracts/
@@ -31,24 +32,24 @@ contracts/
       lib.rs
 ```
 
-Use this structure for future examples:
+What each file is for:
 
-- `README.md`: explains what the example does and how to build or run it
-- `Cargo.toml`: Rust package configuration for the contract
+- `README.md`: explains what the contract does and how to use it
+- `Cargo.toml`: Rust package configuration for that example
 - `src/lib.rs`: the contract source code
 
-## Naming and organization
+## Organization guidelines
 
-To keep this folder easy to browse:
+To keep this folder easy to browse and maintain:
 
-- Use short, descriptive directory names such as `hello-world` or `counter`
-- Keep one example per directory
-- Include a README in every example folder
-- Avoid mixing unrelated contract ideas in the same example
+- Use short, descriptive names such as `hello-world` or `counter`
+- Keep one example contract per directory
+- Include a `README.md` in every example directory
+- Keep examples focused instead of combining unrelated ideas
 
 ## Local usage
 
-To try an example locally, move into that contract's directory and build it from there.
+To try an example locally, start at the repository root and move into the example you want to build.
 
 Example:
 
@@ -57,13 +58,13 @@ cd contracts/hello-world
 cargo build --target wasm32-unknown-unknown --release
 ```
 
-After building, the compiled WASM output will be available in Cargo's `target` directory for that contract.
+After the build finishes, Cargo will place the compiled WASM artifact in that example's `target` directory.
 
-## For contributors
+## Adding a new example
 
-If you add a new contract example:
+If you want to contribute a new contract example:
 
-1. Create a new folder inside `contracts/`
-2. Add the contract source files
-3. Add a short README that explains the example in beginner-friendly language
-4. Keep the example minimal so it is easy for first-time contributors to follow
+1. Create a new folder inside `contracts/`.
+2. Add the contract files for that example.
+3. Add a short README that explains the contract in simple language.
+4. Keep the example small enough for a first-time contributor to follow.


### PR DESCRIPTION
This pull request adds a new `README.md` file to the `contracts` directory, providing clear guidelines and structure for adding and organizing Soroban contract examples. The documentation aims to make it easier for contributors—especially beginners—to create, build, and understand contract examples in the repository.

Documentation and organization improvements:

* Added a comprehensive `README.md` to the `contracts/` directory, outlining the purpose, recommended structure, organization guidelines, local usage instructions, and contribution steps for contract examples.

Closes #17 