### PR TITLE
fix: allow oracle-signed price updates

### DIFF
--- a/contracts/synthetic-assets/src/lib.rs
+++ b/contracts/synthetic-assets/src/lib.rs
@@ -189,7 +189,7 @@ impl SyntheticAssetsContract {
         Ok(())
     }
 
-    /// Update asset price (can be called by oracle or admin)
+    /// Update asset price (oracle-signed)
     pub fn update_price(
         env: Env,
         asset_symbol: Symbol,
@@ -197,7 +197,13 @@ impl SyntheticAssetsContract {
         confidence: u32,
     ) -> Result<(), Error> {
         let admin = get_admin(&env)?;
-        admin.require_auth();
+        let oracle = get_oracle_address(&env)?;
+
+        if admin == oracle {
+            admin.require_auth();
+        } else {
+            oracle.require_auth();
+        }
 
         if !has_synthetic_asset(&env, &asset_symbol) {
             return Err(Error::AssetNotRegistered);


### PR DESCRIPTION
## Closes #312

## Summary
Allows the configured oracle to authorize price updates while preserving admin-only behavior when both addresses are the same.

## Root Cause
Price updates were restricted to the admin address, preventing oracle-driven updates.

## Changes
- Adjusted `update_price` authorization to require the configured oracle, falling back to admin when both addresses are identical