### PR TITLE
fix: add identity management api routes

### DIFF
--- a/backend/src/routes/api.js
+++ b/backend/src/routes/api.js
@@ -2,9 +2,11 @@ import express from 'express';
 import v1Compile from './v1/compile.js';
 import v1Deploy from './v1/deploy.js';
 import v1Invoke from './v1/invoke.js';
+import v1Identity from './v1/identity.js';
 import v2Compile from './v2/compile.js';
 import v2Deploy from './v2/deploy.js';
 import v2Invoke from './v2/invoke.js';
+import v2Identity from './v2/identity.js';
 import eventsRouter from './events.js';
 import { versionTransformer, requestTransformerV2 } from '../middleware/versionTransformer.js';
 import { rateLimitMiddleware } from '../middleware/rateLimiter.js';
@@ -31,6 +33,7 @@ v1Router.use(versionTransformer('v1'));
 v1Router.use('/compile', rateLimitMiddleware('compile'), v1Compile);
 v1Router.use('/deploy', rateLimitMiddleware('deploy'), v1Deploy);
 v1Router.use('/invoke', rateLimitMiddleware('invoke'), v1Invoke);
+v1Router.use('/identity', rateLimitMiddleware('invoke'), v1Identity);
 
 // v2 Routes
 const v2Router = express.Router();
@@ -39,6 +42,7 @@ v2Router.use(requestTransformerV2); // Optional: transform v1-style requests to 
 v2Router.use('/compile', rateLimitMiddleware('compile'), v2Compile);
 v2Router.use('/deploy', rateLimitMiddleware('deploy'), v2Deploy);
 v2Router.use('/invoke', rateLimitMiddleware('invoke'), v2Invoke);
+v2Router.use('/identity', rateLimitMiddleware('invoke'), v2Identity);
 
 // Register versioned routes
 router.use('/v1', v1Router);
@@ -49,6 +53,7 @@ router.use('/oracle', oracleRouter);
 router.use('/compile', versionTransformer('v1'), rateLimitMiddleware('compile'), v1Compile);
 router.use('/deploy', versionTransformer('v1'), rateLimitMiddleware('deploy'), v1Deploy);
 router.use('/invoke', versionTransformer('v1'), rateLimitMiddleware('invoke'), v1Invoke);
+router.use('/identity', versionTransformer('v1'), rateLimitMiddleware('invoke'), v1Identity);
 router.use('/events', eventsRouter);
 
 export default router;

--- a/backend/src/routes/v1/identity.js
+++ b/backend/src/routes/v1/identity.js
@@ -1,0 +1,291 @@
+import express from 'express';
+import { asyncHandler, createHttpError } from '../../middleware/errorHandler.js';
+import { invokeSorobanContract } from '../../services/invokeService.js';
+
+const router = express.Router();
+
+const CONTRACT_ID_RE = /^C[A-Z0-9]{55}$/;
+
+function validateContractId(contractId, errors) {
+  if (!contractId) {
+    errors.push('contractId is required');
+  } else if (typeof contractId !== 'string' || !CONTRACT_ID_RE.test(contractId)) {
+    errors.push('contractId must be a valid Stellar contract ID');
+  }
+}
+
+function validateRequiredString(field, value, errors) {
+  if (!value) {
+    errors.push(`${field} is required`);
+  } else if (typeof value !== 'string') {
+    errors.push(`${field} must be a string`);
+  }
+}
+
+function parseIntField(field, value, errors) {
+  if (value === undefined || value === null || value === '') {
+    errors.push(`${field} is required`);
+    return null;
+  }
+  const parsed = Number.parseInt(String(value), 10);
+  if (Number.isNaN(parsed)) {
+    errors.push(`${field} must be a valid number`);
+    return null;
+  }
+  return parsed;
+}
+
+async function invokeAndRespond(req, res, next, payload) {
+  const requestId = `identity-${payload.functionName}-${Date.now()}-${Math.random()
+    .toString(16)
+    .slice(2, 8)}`;
+  const controller = new AbortController();
+  req.on('aborted', () => controller.abort());
+
+  try {
+    const result = await invokeSorobanContract(
+      {
+        requestId,
+        contractId: payload.contractId,
+        functionName: payload.functionName,
+        args: payload.args,
+        network: payload.network,
+        sourceAccount: payload.sourceAccount,
+      },
+      { signal: controller.signal }
+    );
+
+    return res.json({
+      success: true,
+      status: 'success',
+      contractId: result.contractId,
+      functionName: result.functionName,
+      args: payload.args,
+      output: result.parsed,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      message: `Function "${result.functionName}" invoked successfully`,
+      invokedAt: result.endedAt,
+    });
+  } catch (error) {
+    const details = [
+      error?.message || 'Soroban invocation failed',
+      error?.stderr ? `stderr: ${error.stderr}` : null,
+    ].filter(Boolean);
+    return next(createHttpError(502, 'Invocation failed', details));
+  }
+}
+
+router.post(
+  '/register',
+  asyncHandler(async (req, res, next) => {
+    const { contractId, owner, did, metadataHash, network, sourceAccount } =
+      req.body || {};
+    const errors = [];
+    validateContractId(contractId, errors);
+    validateRequiredString('owner', owner, errors);
+    validateRequiredString('did', did, errors);
+    const metadata = parseIntField('metadataHash', metadataHash, errors);
+
+    if (errors.length) {
+      return next(createHttpError(400, 'Validation failed', errors));
+    }
+
+    return invokeAndRespond(req, res, next, {
+      contractId,
+      functionName: 'register_identity',
+      args: {
+        owner,
+        did,
+        metadata_hash: String(metadata),
+      },
+      network,
+      sourceAccount,
+    });
+  })
+);
+
+router.post(
+  '/metadata',
+  asyncHandler(async (req, res, next) => {
+    const { contractId, owner, metadataHash, network, sourceAccount } =
+      req.body || {};
+    const errors = [];
+    validateContractId(contractId, errors);
+    validateRequiredString('owner', owner, errors);
+    const metadata = parseIntField('metadataHash', metadataHash, errors);
+
+    if (errors.length) {
+      return next(createHttpError(400, 'Validation failed', errors));
+    }
+
+    return invokeAndRespond(req, res, next, {
+      contractId,
+      functionName: 'update_metadata',
+      args: {
+        owner,
+        metadata_hash: String(metadata),
+      },
+      network,
+      sourceAccount,
+    });
+  })
+);
+
+router.post(
+  '/deactivate',
+  asyncHandler(async (req, res, next) => {
+    const { contractId, owner, network, sourceAccount } = req.body || {};
+    const errors = [];
+    validateContractId(contractId, errors);
+    validateRequiredString('owner', owner, errors);
+
+    if (errors.length) {
+      return next(createHttpError(400, 'Validation failed', errors));
+    }
+
+    return invokeAndRespond(req, res, next, {
+      contractId,
+      functionName: 'deactivate_identity',
+      args: { owner },
+      network,
+      sourceAccount,
+    });
+  })
+);
+
+router.post(
+  '/credentials/issue',
+  asyncHandler(async (req, res, next) => {
+    const {
+      contractId,
+      issuer,
+      subject,
+      schemaHash,
+      dataHash,
+      expiresAt,
+      network,
+      sourceAccount,
+    } = req.body || {};
+    const errors = [];
+    validateContractId(contractId, errors);
+    validateRequiredString('issuer', issuer, errors);
+    validateRequiredString('subject', subject, errors);
+    const schema = parseIntField('schemaHash', schemaHash, errors);
+    const data = parseIntField('dataHash', dataHash, errors);
+    const expiry = parseIntField('expiresAt', expiresAt, errors);
+
+    if (errors.length) {
+      return next(createHttpError(400, 'Validation failed', errors));
+    }
+
+    return invokeAndRespond(req, res, next, {
+      contractId,
+      functionName: 'issue_credential',
+      args: {
+        issuer,
+        subject,
+        schema_hash: String(schema),
+        data_hash: String(data),
+        expires_at: String(expiry),
+      },
+      network,
+      sourceAccount,
+    });
+  })
+);
+
+router.post(
+  '/credentials/revoke',
+  asyncHandler(async (req, res, next) => {
+    const { contractId, credentialId, network, sourceAccount } =
+      req.body || {};
+    const errors = [];
+    validateContractId(contractId, errors);
+    const credential = parseIntField('credentialId', credentialId, errors);
+
+    if (errors.length) {
+      return next(createHttpError(400, 'Validation failed', errors));
+    }
+
+    return invokeAndRespond(req, res, next, {
+      contractId,
+      functionName: 'revoke_credential',
+      args: { credential_id: String(credential) },
+      network,
+      sourceAccount,
+    });
+  })
+);
+
+router.post(
+  '/reputation/adjust',
+  asyncHandler(async (req, res, next) => {
+    const { contractId, subject, delta, network, sourceAccount } =
+      req.body || {};
+    const errors = [];
+    validateContractId(contractId, errors);
+    validateRequiredString('subject', subject, errors);
+    const deltaValue = parseIntField('delta', delta, errors);
+
+    if (errors.length) {
+      return next(createHttpError(400, 'Validation failed', errors));
+    }
+
+    return invokeAndRespond(req, res, next, {
+      contractId,
+      functionName: 'adjust_reputation',
+      args: { subject, delta: String(deltaValue) },
+      network,
+      sourceAccount,
+    });
+  })
+);
+
+router.get(
+  '/:owner',
+  asyncHandler(async (req, res, next) => {
+    const { contractId, network, sourceAccount } = req.query || {};
+    const { owner } = req.params;
+    const errors = [];
+    validateContractId(contractId, errors);
+    validateRequiredString('owner', owner, errors);
+
+    if (errors.length) {
+      return next(createHttpError(400, 'Validation failed', errors));
+    }
+
+    return invokeAndRespond(req, res, next, {
+      contractId,
+      functionName: 'get_identity',
+      args: { owner },
+      network,
+      sourceAccount,
+    });
+  })
+);
+
+router.get(
+  '/credentials/:credentialId',
+  asyncHandler(async (req, res, next) => {
+    const { contractId, network, sourceAccount } = req.query || {};
+    const { credentialId } = req.params;
+    const errors = [];
+    validateContractId(contractId, errors);
+    const credential = parseIntField('credentialId', credentialId, errors);
+
+    if (errors.length) {
+      return next(createHttpError(400, 'Validation failed', errors));
+    }
+
+    return invokeAndRespond(req, res, next, {
+      contractId,
+      functionName: 'get_credential',
+      args: { credential_id: String(credential) },
+      network,
+      sourceAccount,
+    });
+  })
+);
+
+export default router;

--- a/backend/src/routes/v2/identity.js
+++ b/backend/src/routes/v2/identity.js
@@ -1,0 +1,297 @@
+import express from 'express';
+import { asyncHandler, createHttpError } from '../../middleware/errorHandler.js';
+import { invokeSorobanContract } from '../../services/invokeService.js';
+
+const router = express.Router();
+
+const CONTRACT_ID_RE = /^C[A-Z0-9]{55}$/;
+
+function validateContractId(contractId, errors) {
+  if (!contractId) {
+    errors.push('contract_id is required');
+  } else if (typeof contractId !== 'string' || !CONTRACT_ID_RE.test(contractId)) {
+    errors.push('contract_id must be a valid Stellar contract ID');
+  }
+}
+
+function validateRequiredString(field, value, errors) {
+  if (!value) {
+    errors.push(`${field} is required`);
+  } else if (typeof value !== 'string') {
+    errors.push(`${field} must be a string`);
+  }
+}
+
+function parseIntField(field, value, errors) {
+  if (value === undefined || value === null || value === '') {
+    errors.push(`${field} is required`);
+    return null;
+  }
+  const parsed = Number.parseInt(String(value), 10);
+  if (Number.isNaN(parsed)) {
+    errors.push(`${field} must be a valid number`);
+    return null;
+  }
+  return parsed;
+}
+
+async function invokeAndRespond(req, res, next, payload) {
+  const requestId = `identity-${payload.functionName}-${Date.now()}-${Math.random()
+    .toString(16)
+    .slice(2, 8)}`;
+  const controller = new AbortController();
+  req.on('aborted', () => controller.abort());
+
+  try {
+    const result = await invokeSorobanContract(
+      {
+        requestId,
+        contractId: payload.contractId,
+        functionName: payload.functionName,
+        args: payload.args,
+        network: payload.network,
+        sourceAccount: payload.sourceAccount,
+      },
+      { signal: controller.signal }
+    );
+
+    return res.json({
+      success: true,
+      status: 'success',
+      contract_id: result.contractId,
+      function_name: result.functionName,
+      args: payload.args,
+      output: result.parsed,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      message: `Function "${result.functionName}" invoked successfully`,
+      invoked_at: result.endedAt,
+    });
+  } catch (error) {
+    const details = [
+      error?.message || 'Soroban invocation failed',
+      error?.stderr ? `stderr: ${error.stderr}` : null,
+    ].filter(Boolean);
+    return next(createHttpError(502, 'Invocation failed', details));
+  }
+}
+
+router.post(
+  '/register',
+  asyncHandler(async (req, res, next) => {
+    const {
+      contract_id,
+      owner,
+      did,
+      metadata_hash,
+      network,
+      source_account,
+    } = req.body || {};
+    const errors = [];
+    validateContractId(contract_id, errors);
+    validateRequiredString('owner', owner, errors);
+    validateRequiredString('did', did, errors);
+    const metadata = parseIntField('metadata_hash', metadata_hash, errors);
+
+    if (errors.length) {
+      return next(createHttpError(400, 'Validation failed', errors));
+    }
+
+    return invokeAndRespond(req, res, next, {
+      contractId: contract_id,
+      functionName: 'register_identity',
+      args: {
+        owner,
+        did,
+        metadata_hash: String(metadata),
+      },
+      network,
+      sourceAccount: source_account,
+    });
+  })
+);
+
+router.post(
+  '/metadata',
+  asyncHandler(async (req, res, next) => {
+    const { contract_id, owner, metadata_hash, network, source_account } =
+      req.body || {};
+    const errors = [];
+    validateContractId(contract_id, errors);
+    validateRequiredString('owner', owner, errors);
+    const metadata = parseIntField('metadata_hash', metadata_hash, errors);
+
+    if (errors.length) {
+      return next(createHttpError(400, 'Validation failed', errors));
+    }
+
+    return invokeAndRespond(req, res, next, {
+      contractId: contract_id,
+      functionName: 'update_metadata',
+      args: {
+        owner,
+        metadata_hash: String(metadata),
+      },
+      network,
+      sourceAccount: source_account,
+    });
+  })
+);
+
+router.post(
+  '/deactivate',
+  asyncHandler(async (req, res, next) => {
+    const { contract_id, owner, network, source_account } = req.body || {};
+    const errors = [];
+    validateContractId(contract_id, errors);
+    validateRequiredString('owner', owner, errors);
+
+    if (errors.length) {
+      return next(createHttpError(400, 'Validation failed', errors));
+    }
+
+    return invokeAndRespond(req, res, next, {
+      contractId: contract_id,
+      functionName: 'deactivate_identity',
+      args: { owner },
+      network,
+      sourceAccount: source_account,
+    });
+  })
+);
+
+router.post(
+  '/credentials/issue',
+  asyncHandler(async (req, res, next) => {
+    const {
+      contract_id,
+      issuer,
+      subject,
+      schema_hash,
+      data_hash,
+      expires_at,
+      network,
+      source_account,
+    } = req.body || {};
+    const errors = [];
+    validateContractId(contract_id, errors);
+    validateRequiredString('issuer', issuer, errors);
+    validateRequiredString('subject', subject, errors);
+    const schema = parseIntField('schema_hash', schema_hash, errors);
+    const data = parseIntField('data_hash', data_hash, errors);
+    const expiry = parseIntField('expires_at', expires_at, errors);
+
+    if (errors.length) {
+      return next(createHttpError(400, 'Validation failed', errors));
+    }
+
+    return invokeAndRespond(req, res, next, {
+      contractId: contract_id,
+      functionName: 'issue_credential',
+      args: {
+        issuer,
+        subject,
+        schema_hash: String(schema),
+        data_hash: String(data),
+        expires_at: String(expiry),
+      },
+      network,
+      sourceAccount: source_account,
+    });
+  })
+);
+
+router.post(
+  '/credentials/revoke',
+  asyncHandler(async (req, res, next) => {
+    const { contract_id, credential_id, network, source_account } =
+      req.body || {};
+    const errors = [];
+    validateContractId(contract_id, errors);
+    const credential = parseIntField('credential_id', credential_id, errors);
+
+    if (errors.length) {
+      return next(createHttpError(400, 'Validation failed', errors));
+    }
+
+    return invokeAndRespond(req, res, next, {
+      contractId: contract_id,
+      functionName: 'revoke_credential',
+      args: { credential_id: String(credential) },
+      network,
+      sourceAccount: source_account,
+    });
+  })
+);
+
+router.post(
+  '/reputation/adjust',
+  asyncHandler(async (req, res, next) => {
+    const { contract_id, subject, delta, network, source_account } =
+      req.body || {};
+    const errors = [];
+    validateContractId(contract_id, errors);
+    validateRequiredString('subject', subject, errors);
+    const deltaValue = parseIntField('delta', delta, errors);
+
+    if (errors.length) {
+      return next(createHttpError(400, 'Validation failed', errors));
+    }
+
+    return invokeAndRespond(req, res, next, {
+      contractId: contract_id,
+      functionName: 'adjust_reputation',
+      args: { subject, delta: String(deltaValue) },
+      network,
+      sourceAccount: source_account,
+    });
+  })
+);
+
+router.get(
+  '/:owner',
+  asyncHandler(async (req, res, next) => {
+    const { contract_id, network, source_account } = req.query || {};
+    const { owner } = req.params;
+    const errors = [];
+    validateContractId(contract_id, errors);
+    validateRequiredString('owner', owner, errors);
+
+    if (errors.length) {
+      return next(createHttpError(400, 'Validation failed', errors));
+    }
+
+    return invokeAndRespond(req, res, next, {
+      contractId: contract_id,
+      functionName: 'get_identity',
+      args: { owner },
+      network,
+      sourceAccount: source_account,
+    });
+  })
+);
+
+router.get(
+  '/credentials/:credentialId',
+  asyncHandler(async (req, res, next) => {
+    const { contract_id, network, source_account } = req.query || {};
+    const { credentialId } = req.params;
+    const errors = [];
+    validateContractId(contract_id, errors);
+    const credential = parseIntField('credential_id', credentialId, errors);
+
+    if (errors.length) {
+      return next(createHttpError(400, 'Validation failed', errors));
+    }
+
+    return invokeAndRespond(req, res, next, {
+      contractId: contract_id,
+      functionName: 'get_credential',
+      args: { credential_id: String(credential) },
+      network,
+      sourceAccount: source_account,
+    });
+  })
+);
+
+export default router;


### PR DESCRIPTION

Closes #341

---

### Issue Summary

Backend lacked dedicated REST endpoints for DID identity and credential operations.

---

### Root Cause

Only generic invoke endpoints were present; no identity-focused routes were wired into the API router.

---

### Fix Implemented

- Added v1 and v2 identity routes with input validation delegating to `invokeSorobanContract`
- Registered identity routes in the versioned router

---

### References

- Closes #341