### PR TITLE
feat: Pause Toggle Contract for Emergency Circuit Breakers (#608)

### DIFF
--- a/backend/src/routes/api.js
+++ b/backend/src/routes/api.js
@@ -75,4 +75,8 @@ import musicLicensingRoutes from './musicLicensingRoutes.js';
 router.use('/music-licensing', musicLicensingRoutes);
 
 router.use('/warranty', warrantyRoutes);
+
+import pauseToggleRoutes from './pauseToggle.js';
+router.use('/pause-toggle', pauseToggleRoutes);
+
 export default router;

--- a/backend/src/routes/pauseToggle.js
+++ b/backend/src/routes/pauseToggle.js
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 StellarDevTools
+// SPDX-License-Identifier: MIT
+
+/**
+ * @openapi
+ * tags:
+ *   - name: Pause Toggle
+ *     description: Emergency circuit-breaker for Soroban contracts
+ */
+
+import express from 'express';
+import service from '../services/pauseToggleService.js';
+import { rateLimitMiddleware } from '../middleware/rateLimiter.js';
+
+const router = express.Router();
+
+function requireFields(body, fields) {
+  const missing = fields.filter(
+    (f) => body[f] === undefined || body[f] === null || body[f] === ''
+  );
+  return missing.length ? missing : null;
+}
+
+function sendError(res, status, message) {
+  return res.status(status).json({ success: false, error: message });
+}
+
+/**
+ * @openapi
+ * /api/pause-toggle/init:
+ *   post:
+ *     tags: [Pause Toggle]
+ *     summary: Initialize the pause-toggle contract
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [contractId, admin]
+ *             properties:
+ *               contractId: { type: string }
+ *               admin: { type: string }
+ *     responses:
+ *       200:
+ *         description: Initialized
+ *       400:
+ *         description: Validation error
+ */
+router.post('/init', rateLimitMiddleware('invoke'), async (req, res) => {
+  const missing = requireFields(req.body, ['contractId', 'admin']);
+  if (missing) return sendError(res, 400, `Missing fields: ${missing.join(', ')}`);
+  try {
+    const data = await service.initialize(req.body.contractId, req.body.admin);
+    return res.json({ success: true, data });
+  } catch (err) {
+    return sendError(res, 500, err.message);
+  }
+});
+
+/**
+ * @openapi
+ * /api/pause-toggle/pause:
+ *   post:
+ *     tags: [Pause Toggle]
+ *     summary: Pause the contract
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [contractId, caller]
+ *             properties:
+ *               contractId: { type: string }
+ *               caller: { type: string }
+ *               reason: { type: string, description: "Optional pause reason" }
+ *     responses:
+ *       200:
+ *         description: Paused
+ *       400:
+ *         description: Validation error
+ */
+router.post('/pause', rateLimitMiddleware('invoke'), async (req, res) => {
+  const missing = requireFields(req.body, ['contractId', 'caller']);
+  if (missing) return sendError(res, 400, `Missing fields: ${missing.join(', ')}`);
+  try {
+    const data = await service.pause(
+      req.body.contractId,
+      req.body.caller,
+      req.body.reason ?? null
+    );
+    return res.json({ success: true, data });
+  } catch (err) {
+    return sendError(res, 500, err.message);
+  }
+});
+
+/**
+ * @openapi
+ * /api/pause-toggle/unpause:
+ *   post:
+ *     tags: [Pause Toggle]
+ *     summary: Unpause the contract
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [contractId, caller]
+ *             properties:
+ *               contractId: { type: string }
+ *               caller: { type: string }
+ *     responses:
+ *       200:
+ *         description: Unpaused
+ */
+router.post('/unpause', rateLimitMiddleware('invoke'), async (req, res) => {
+  const missing = requireFields(req.body, ['contractId', 'caller']);
+  if (missing) return sendError(res, 400, `Missing fields: ${missing.join(', ')}`);
+  try {
+    const data = await service.unpause(req.body.contractId, req.body.caller);
+    return res.json({ success: true, data });
+  } catch (err) {
+    return sendError(res, 500, err.message);
+  }
+});
+
+/**
+ * @openapi
+ * /api/pause-toggle/status:
+ *   get:
+ *     tags: [Pause Toggle]
+ *     summary: Get the paused state
+ *     parameters:
+ *       - in: query
+ *         name: contractId
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: Paused state
+ */
+router.get('/status', async (req, res) => {
+  const { contractId } = req.query;
+  if (!contractId) return sendError(res, 400, 'Missing contractId');
+  try {
+    const paused = await service.isPaused(contractId);
+    return res.json({ success: true, data: { paused } });
+  } catch (err) {
+    return sendError(res, 500, err.message);
+  }
+});
+
+/**
+ * @openapi
+ * /api/pause-toggle/reason:
+ *   get:
+ *     tags: [Pause Toggle]
+ *     summary: Get the pause reason (null if not paused or no reason given)
+ *     parameters:
+ *       - in: query
+ *         name: contractId
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: Pause reason
+ */
+router.get('/reason', async (req, res) => {
+  const { contractId } = req.query;
+  if (!contractId) return sendError(res, 400, 'Missing contractId');
+  try {
+    const reason = await service.getPauseReason(contractId);
+    return res.json({ success: true, data: { reason } });
+  } catch (err) {
+    return sendError(res, 500, err.message);
+  }
+});
+
+/**
+ * @openapi
+ * /api/pause-toggle/timestamp:
+ *   get:
+ *     tags: [Pause Toggle]
+ *     summary: Get the ledger timestamp when the contract was paused (null if not paused)
+ *     parameters:
+ *       - in: query
+ *         name: contractId
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: Pause timestamp
+ */
+router.get('/timestamp', async (req, res) => {
+  const { contractId } = req.query;
+  if (!contractId) return sendError(res, 400, 'Missing contractId');
+  try {
+    const timestamp = await service.getPauseTimestamp(contractId);
+    return res.json({ success: true, data: { timestamp } });
+  } catch (err) {
+    return sendError(res, 500, err.message);
+  }
+});
+
+/**
+ * @openapi
+ * /api/pause-toggle/admin:
+ *   get:
+ *     tags: [Pause Toggle]
+ *     summary: Get the admin address
+ *     parameters:
+ *       - in: query
+ *         name: contractId
+ *         required: true
+ *         schema: { type: string }
+ *     responses:
+ *       200:
+ *         description: Admin address
+ */
+router.get('/admin', async (req, res) => {
+  const { contractId } = req.query;
+  if (!contractId) return sendError(res, 400, 'Missing contractId');
+  try {
+    const admin = await service.getAdmin(contractId);
+    return res.json({ success: true, data: { admin } });
+  } catch (err) {
+    return sendError(res, 500, err.message);
+  }
+});
+
+export default router;

--- a/backend/src/services/pauseToggleService.js
+++ b/backend/src/services/pauseToggleService.js
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 StellarDevTools
+// SPDX-License-Identifier: MIT
+
+import { invokeContract } from './invokeService.js';
+import cacheService from './cacheService.js';
+
+const CACHE_TTL = 30; // seconds
+
+export async function initialize(contractId, admin) {
+  return invokeContract({
+    contractId,
+    functionName: 'init',
+    args: { admin },
+    network: 'testnet',
+  });
+}
+
+export async function pause(contractId, caller, reason = null) {
+  const args = { caller, reason: reason ?? null };
+  const result = await invokeContract({
+    contractId,
+    functionName: 'pause',
+    args,
+    network: 'testnet',
+  });
+  await cacheService.del(`pt:status:${contractId}`);
+  await cacheService.del(`pt:reason:${contractId}`);
+  await cacheService.del(`pt:timestamp:${contractId}`);
+  return result;
+}
+
+export async function unpause(contractId, caller) {
+  const result = await invokeContract({
+    contractId,
+    functionName: 'unpause',
+    args: { caller },
+    network: 'testnet',
+  });
+  await cacheService.del(`pt:status:${contractId}`);
+  await cacheService.del(`pt:reason:${contractId}`);
+  await cacheService.del(`pt:timestamp:${contractId}`);
+  return result;
+}
+
+export async function isPaused(contractId) {
+  const key = `pt:status:${contractId}`;
+  const cached = await cacheService.get(key);
+  if (cached !== null) return cached === 'true';
+  const result = await invokeContract({
+    contractId,
+    functionName: 'paused',
+    args: {},
+    network: 'testnet',
+  });
+  await cacheService.set(key, String(result), CACHE_TTL);
+  return result;
+}
+
+export async function getPauseReason(contractId) {
+  const key = `pt:reason:${contractId}`;
+  const cached = await cacheService.get(key);
+  if (cached !== null) return cached === 'null' ? null : cached;
+  const result = await invokeContract({
+    contractId,
+    functionName: 'get_pause_reason',
+    args: {},
+    network: 'testnet',
+  });
+  await cacheService.set(key, result === null ? 'null' : result, CACHE_TTL);
+  return result;
+}
+
+export async function getPauseTimestamp(contractId) {
+  const key = `pt:timestamp:${contractId}`;
+  const cached = await cacheService.get(key);
+  if (cached !== null) return cached === 'null' ? null : Number(cached);
+  const result = await invokeContract({
+    contractId,
+    functionName: 'get_pause_timestamp',
+    args: {},
+    network: 'testnet',
+  });
+  await cacheService.set(key, result === null ? 'null' : String(result), CACHE_TTL);
+  return result;
+}
+
+export async function getAdmin(contractId) {
+  return invokeContract({
+    contractId,
+    functionName: 'get_admin',
+    args: {},
+    network: 'testnet',
+  });
+}
+
+export default {
+  initialize,
+  pause,
+  unpause,
+  isPaused,
+  getPauseReason,
+  getPauseTimestamp,
+  getAdmin,
+};

--- a/contracts/pause-toggle-contract/README.md
+++ b/contracts/pause-toggle-contract/README.md
@@ -1,22 +1,165 @@
-# Soroban Project
+# Pause Toggle Contract
 
-## Project Structure
+An emergency circuit-breaker for Soroban smart contracts. Provides admin-controlled pause/unpause functionality, audit information (reason and timestamp), and a guarded action pattern that any contract can adopt.
 
-This repository uses the recommended structure for a Soroban project:
+## Features
 
-```text
-.
-├── contracts
-│   └── hello_world
-│       ├── src
-│       │   ├── lib.rs
-│       │   └── test.rs
-│       └── Cargo.toml
-├── Cargo.toml
-└── README.md
+- `init(admin)` — one-time initialization
+- `pause(caller, reason?)` — halt operations, record why and when
+- `unpause(caller)` — resume operations, clear audit data
+- `paused()` — read current state
+- `get_pause_reason()` — retrieve the reason the contract was paused
+- `get_pause_timestamp()` — retrieve the ledger timestamp of the last pause
+- `get_admin()` — retrieve the admin address
+- `do_action(caller)` — example of a guarded function
+
+## Contract Interface
+
+| Function | Parameters | Returns | Access |
+|---|---|---|---|
+| `init` | `admin: Address` | `void` | Public (once) |
+| `pause` | `caller: Address, reason: Option<String>` | `Result<(), Error>` | Admin only |
+| `unpause` | `caller: Address` | `Result<(), Error>` | Admin only |
+| `paused` | — | `bool` | Read |
+| `get_pause_reason` | — | `Option<String>` | Read |
+| `get_pause_timestamp` | — | `Option<u64>` | Read |
+| `get_admin` | — | `Result<Address, Error>` | Read |
+| `do_action` | `caller: Address` | `Result<(), Error>` | Any (guarded) |
+
+## Error Codes
+
+| Code | Variant | Meaning |
+|---|---|---|
+| 1 | `Unauthorized` | Caller is not the admin |
+| 2 | `ContractPaused` | Action blocked by pause guard |
+| 3 | `AlreadyInState` | Already paused / already unpaused |
+| 4 | `NotInitialized` | `init` has not been called |
+
+## Events
+
+| Topic | Data | Emitted When |
+|---|---|---|
+| `init` | `admin: Address` | Contract initialized |
+| `paused` | `(caller: Address, timestamp: u64)` | Contract paused |
+| `unpaused` | `caller: Address` | Contract unpaused |
+| `action` | `caller: Address` | Guarded action executed |
+
+## Security Patterns
+
+- **Admin-only control**: `pause` and `unpause` call `require_auth()` and verify the caller matches the stored admin.
+- **Checks-effects-interactions**: state is written before events are emitted.
+- **Audit trail**: pause reason and timestamp are stored on-chain and cleared on unpause.
+- **No re-entrancy surface**: contract holds no token balances.
+
+## Usage Example
+
+```rust
+// In your contract, add a guard to any sensitive function:
+fn transfer(env: Env, from: Address, to: Address, amount: i128) -> Result<(), Error> {
+    if pause_toggle_client.paused() {
+        return Err(Error::ContractPaused);
+    }
+    // ... transfer logic
+}
 ```
 
-- New Soroban contracts can be put in `contracts`, each in their own directory. There is already a `hello_world` contract in there to get you started.
-- If you initialized this project with any other example contracts via `--with-example`, those contracts will be in the `contracts` directory as well.
-- Contracts should have their own `Cargo.toml` files that rely on the top-level `Cargo.toml` workspace for their dependencies.
-- Frontend libraries can be added to the top-level directory as well. If you initialized this project with a frontend template via `--frontend-template` you will have those files already included.
+## Building
+
+```bash
+cd contracts/pause-toggle-contract
+cargo build --target wasm32-unknown-unknown --release
+```
+
+## Testing
+
+```bash
+cd contracts/pause-toggle-contract
+cargo test
+```
+
+The test suite contains 60+ cases covering:
+- Initialization (single-init enforcement, admin set, default state)
+- Pause (flag, reason, timestamp, admin-only, idempotency)
+- Unpause (flag cleared, reason cleared, timestamp cleared, admin-only, idempotency)
+- `get_pause_reason` (before/after pause, after unpause, across cycles)
+- `get_pause_timestamp` (before/after pause, after unpause, across cycles)
+- Guarded action (allowed, blocked, allowed again after unpause)
+- Full multi-cycle lifecycle
+- Property tests (non-admin cannot change state)
+
+## Deploying to Testnet
+
+```bash
+# Build
+cargo build --target wasm32-unknown-unknown --release
+
+# Deploy
+stellar contract deploy \
+  --wasm target/wasm32-unknown-unknown/release/pause_toggle.wasm \
+  --source <YOUR_ACCOUNT> \
+  --network testnet
+
+# Initialize
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source <YOUR_ACCOUNT> \
+  --network testnet \
+  -- init \
+  --admin <ADMIN_ADDRESS>
+
+# Pause with a reason
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ADMIN_ACCOUNT> \
+  --network testnet \
+  -- pause \
+  --caller <ADMIN_ADDRESS> \
+  --reason "Security vulnerability patched, halting until audit"
+
+# Check pause reason
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --network testnet \
+  -- get_pause_reason
+
+# Unpause
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ADMIN_ACCOUNT> \
+  --network testnet \
+  -- unpause \
+  --caller <ADMIN_ADDRESS>
+```
+
+## Backend API
+
+Base URL: `http://localhost:5000/api/pause-toggle`
+
+| Method | Endpoint | Description |
+|---|---|---|
+| POST | `/init` | Initialize the contract |
+| POST | `/pause` | Pause the contract |
+| POST | `/unpause` | Unpause the contract |
+| GET | `/status?contractId=` | Get paused state |
+| GET | `/reason?contractId=` | Get pause reason |
+| GET | `/timestamp?contractId=` | Get pause timestamp |
+| GET | `/admin?contractId=` | Get admin address |
+
+### Example: Pause with reason
+
+```bash
+curl -X POST http://localhost:5000/api/pause-toggle/pause \
+  -H "Content-Type: application/json" \
+  -d '{
+    "contractId": "C...",
+    "caller": "G...",
+    "reason": "Exploit detected in transfer function"
+  }'
+```
+
+### Example: Get audit info
+
+```bash
+curl "http://localhost:5000/api/pause-toggle/reason?contractId=C..."
+curl "http://localhost:5000/api/pause-toggle/timestamp?contractId=C..."
+```

--- a/contracts/pause-toggle-contract/src/lib.rs
+++ b/contracts/pause-toggle-contract/src/lib.rs
@@ -1,6 +1,25 @@
+// Copyright (c) 2026 StellarDevTools
+// SPDX-License-Identifier: MIT
+
+//! # Pause Toggle Contract
+//!
+//! Emergency circuit-breaker pattern for Soroban smart contracts.
+//!
+//! ## Features
+//! - `init` / `pause` / `unpause` lifecycle
+//! - `get_pause_reason` — retrieve why the contract was paused
+//! - `get_pause_timestamp` — retrieve when the contract was paused
+//! - Admin-only control via `require_auth()`
+//! - Event emissions: `init`, `paused`, `unpaused`
+//! - Guarded action example via `do_action`
+
 #![cfg_attr(not(test), no_std)]
 
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env};
+mod test;
+
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Env, String};
+
+// ── Error types ───────────────────────────────────────────────────────────────
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -16,49 +35,46 @@ pub enum Error {
     NotInitialized = 4,
 }
 
+// ── Storage keys ──────────────────────────────────────────────────────────────
+
 #[contracttype]
 pub enum DataKey {
-    /// The admin address — only admin can pause/unpause.
     Admin,
-    /// The current paused state.
     Paused,
+    PauseReason,
+    PauseTimestamp,
 }
+
+// ── Contract ──────────────────────────────────────────────────────────────────
 
 #[contract]
 pub struct PauseToggle;
 
 #[contractimpl]
 impl PauseToggle {
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+
     /// Initializes the contract with an admin address.
-    ///
-    /// Can only be called once. Sets the contract to unpaused by default.
-    ///
-    /// # Errors
-    /// Panics if already initialized.
+    /// Sets the contract to unpaused by default. Panics if already initialized.
     pub fn init(env: Env, admin: Address) {
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("already initialized");
         }
-
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Paused, &false);
-
-        env.events().publish(
-            (soroban_sdk::symbol_short!("init"),),
-            admin,
-        );
+        env.events()
+            .publish((soroban_sdk::symbol_short!("init"),), admin);
     }
 
-    /// Pauses the contract.
-    ///
-    /// Only the admin can call this. Blocked actions will return
-    /// [`Error::ContractPaused`] until [`unpause`] is called.
+    // ── Pause controls ────────────────────────────────────────────────────────
+
+    /// Pauses the contract with an optional reason string.
     ///
     /// # Errors
-    /// Returns [`Error::Unauthorized`] if caller is not the admin.
-    /// Returns [`Error::AlreadyInState`] if already paused.
-    /// Returns [`Error::NotInitialized`] if init has not been called.
-    pub fn pause(env: Env, caller: Address) -> Result<(), Error> {
+    /// - `NotInitialized` — if `init` has not been called.
+    /// - `Unauthorized` — if caller is not the admin.
+    /// - `AlreadyInState` — if already paused.
+    pub fn pause(env: Env, caller: Address, reason: Option<String>) -> Result<(), Error> {
         caller.require_auth();
         Self::assert_initialized(&env)?;
         Self::assert_admin(&env, &caller)?;
@@ -69,22 +85,27 @@ impl PauseToggle {
 
         env.storage().instance().set(&DataKey::Paused, &true);
 
-        env.events().publish(
-            (soroban_sdk::symbol_short!("paused"),),
-            caller,
-        );
+        let now = env.ledger().timestamp();
+        env.storage()
+            .instance()
+            .set(&DataKey::PauseTimestamp, &now);
+
+        if let Some(r) = &reason {
+            env.storage().instance().set(&DataKey::PauseReason, r);
+        }
+
+        env.events()
+            .publish((soroban_sdk::symbol_short!("paused"),), (caller, now));
 
         Ok(())
     }
 
     /// Unpauses the contract.
     ///
-    /// Only the admin can call this.
-    ///
     /// # Errors
-    /// Returns [`Error::Unauthorized`] if caller is not the admin.
-    /// Returns [`Error::AlreadyInState`] if already unpaused.
-    /// Returns [`Error::NotInitialized`] if init has not been called.
+    /// - `NotInitialized` — if `init` has not been called.
+    /// - `Unauthorized` — if caller is not the admin.
+    /// - `AlreadyInState` — if already unpaused.
     pub fn unpause(env: Env, caller: Address) -> Result<(), Error> {
         caller.require_auth();
         Self::assert_initialized(&env)?;
@@ -95,46 +116,42 @@ impl PauseToggle {
         }
 
         env.storage().instance().set(&DataKey::Paused, &false);
+        env.storage().instance().remove(&DataKey::PauseReason);
+        env.storage().instance().remove(&DataKey::PauseTimestamp);
 
-        env.events().publish(
-            (soroban_sdk::symbol_short!("unpaused"),),
-            caller,
-        );
+        env.events()
+            .publish((soroban_sdk::symbol_short!("unpaused"),), caller);
 
         Ok(())
     }
+
+    // ── Queries ───────────────────────────────────────────────────────────────
 
     /// Returns `true` if the contract is currently paused.
     pub fn paused(env: Env) -> bool {
         Self::is_paused(&env)
     }
 
-    /// Example of a guarded action — only runs when not paused.
-    ///
-    /// Replace this with your real business logic. This demonstrates
-    /// how any function checks the pause state before proceeding.
-    ///
-    /// # Errors
-    /// Returns [`Error::ContractPaused`] if the contract is paused.
-    pub fn do_action(env: Env, caller: Address) -> Result<(), Error> {
-        caller.require_auth();
+    /// Returns the reason the contract was paused, if one was recorded.
+    /// Returns `None` when not paused or when no reason was given.
+    pub fn get_pause_reason(env: Env) -> Option<String> {
+        env.storage()
+            .instance()
+            .get(&DataKey::PauseReason)
+    }
 
-        if Self::is_paused(&env) {
-            return Err(Error::ContractPaused);
-        }
-
-        env.events().publish(
-            (soroban_sdk::symbol_short!("action"),),
-            caller,
-        );
-
-        Ok(())
+    /// Returns the ledger timestamp at which the contract was paused.
+    /// Returns `None` when not paused.
+    pub fn get_pause_timestamp(env: Env) -> Option<u64> {
+        env.storage()
+            .instance()
+            .get(&DataKey::PauseTimestamp)
     }
 
     /// Returns the current admin address.
     ///
     /// # Errors
-    /// Returns [`Error::NotInitialized`] if init has not been called.
+    /// - `NotInitialized` — if `init` has not been called.
     pub fn get_admin(env: Env) -> Result<Address, Error> {
         env.storage()
             .instance()
@@ -142,7 +159,26 @@ impl PauseToggle {
             .ok_or(Error::NotInitialized)
     }
 
-    // ── Internal helpers ─────────────────────────────────────────────────────
+    // ── Guarded action ────────────────────────────────────────────────────────
+
+    /// Example guarded action — blocked when paused.
+    ///
+    /// Replace with real business logic. Any function that should be halted
+    /// during an emergency calls `is_paused` first.
+    ///
+    /// # Errors
+    /// - `ContractPaused` — if the contract is paused.
+    pub fn do_action(env: Env, caller: Address) -> Result<(), Error> {
+        caller.require_auth();
+        if Self::is_paused(&env) {
+            return Err(Error::ContractPaused);
+        }
+        env.events()
+            .publish((soroban_sdk::symbol_short!("action"),), caller);
+        Ok(())
+    }
+
+    // ── Internals ─────────────────────────────────────────────────────────────
 
     fn is_paused(env: &Env) -> bool {
         env.storage()
@@ -157,11 +193,9 @@ impl PauseToggle {
             .instance()
             .get(&DataKey::Admin)
             .ok_or(Error::NotInitialized)?;
-
         if &admin != caller {
             return Err(Error::Unauthorized);
         }
-
         Ok(())
     }
 
@@ -170,175 +204,5 @@ impl PauseToggle {
             return Err(Error::NotInitialized);
         }
         Ok(())
-    }
-}
-
-// ============================================================================
-// Tests
-// ============================================================================
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use soroban_sdk::{testutils::Address as _, Env};
-
-    fn setup() -> (Env, Address, PauseToggleClient<'static>) {
-        let env = Env::default();
-        env.mock_all_auths();
-        let id = env.register_contract(None, PauseToggle);
-        let client = PauseToggleClient::new(&env, &id);
-        let admin = Address::generate(&env);
-        client.init(&admin);
-        let env = std::boxed::Box::leak(std::boxed::Box::new(env));
-        let client = PauseToggleClient::new(env, &id);
-        (env.clone(), admin, client)
-    }
-
-    // ── init ─────────────────────────────────────────────────────────────────
-
-    #[test]
-    fn test_init_sets_admin() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let id = env.register_contract(None, PauseToggle);
-        let client = PauseToggleClient::new(&env, &id);
-        let admin = Address::generate(&env);
-
-        client.init(&admin);
-        assert_eq!(client.get_admin(), admin);
-    }
-
-    #[test]
-    fn test_init_starts_unpaused() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let id = env.register_contract(None, PauseToggle);
-        let client = PauseToggleClient::new(&env, &id);
-        let admin = Address::generate(&env);
-
-        client.init(&admin);
-        assert!(!client.paused());
-    }
-
-    #[test]
-    #[should_panic(expected = "already initialized")]
-    fn test_init_twice_panics() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let id = env.register_contract(None, PauseToggle);
-        let client = PauseToggleClient::new(&env, &id);
-        let admin = Address::generate(&env);
-
-        client.init(&admin);
-        client.init(&admin); // should panic
-    }
-
-    // ── pause ─────────────────────────────────────────────────────────────────
-
-    #[test]
-    fn test_pause_sets_paused_state() {
-        let (_, admin, client) = setup();
-        client.pause(&admin);
-        assert!(client.paused());
-    }
-
-    #[test]
-    fn test_pause_by_non_admin_fails() {
-        let (env, _, client) = setup();
-        let stranger = Address::generate(&env);
-
-        let result = client.try_pause(&stranger);
-        assert_eq!(result, Err(Ok(Error::Unauthorized)));
-    }
-
-    #[test]
-    fn test_pause_already_paused_fails() {
-        let (_, admin, client) = setup();
-        client.pause(&admin);
-
-        let result = client.try_pause(&admin);
-        assert_eq!(result, Err(Ok(Error::AlreadyInState)));
-    }
-
-    // ── unpause ───────────────────────────────────────────────────────────────
-
-    #[test]
-    fn test_unpause_clears_paused_state() {
-        let (_, admin, client) = setup();
-        client.pause(&admin);
-        assert!(client.paused());
-
-        client.unpause(&admin);
-        assert!(!client.paused());
-    }
-
-    #[test]
-    fn test_unpause_by_non_admin_fails() {
-        let (env, admin, client) = setup();
-        client.pause(&admin);
-        let stranger = Address::generate(&env);
-
-        let result = client.try_unpause(&stranger);
-        assert_eq!(result, Err(Ok(Error::Unauthorized)));
-    }
-
-    #[test]
-    fn test_unpause_already_active_fails() {
-        let (_, admin, client) = setup();
-
-        // Contract starts unpaused
-        let result = client.try_unpause(&admin);
-        assert_eq!(result, Err(Ok(Error::AlreadyInState)));
-    }
-
-    // ── do_action ─────────────────────────────────────────────────────────────
-
-    #[test]
-    fn test_action_succeeds_when_unpaused() {
-        let (env, _, client) = setup();
-        let user = Address::generate(&env);
-        // Should not error
-        client.do_action(&user);
-    }
-
-    #[test]
-    fn test_action_blocked_when_paused() {
-        let (env, admin, client) = setup();
-        let user = Address::generate(&env);
-        client.pause(&admin);
-
-        let result = client.try_do_action(&user);
-        assert_eq!(result, Err(Ok(Error::ContractPaused)));
-    }
-
-    #[test]
-    fn test_action_works_after_unpause() {
-        let (env, admin, client) = setup();
-        let user = Address::generate(&env);
-
-        client.pause(&admin);
-        client.unpause(&admin);
-
-        // Should succeed again
-        client.do_action(&user);
-    }
-
-    // ── full cycle ────────────────────────────────────────────────────────────
-
-    #[test]
-    fn test_full_pause_unpause_cycle() {
-        let (env, admin, client) = setup();
-        let user = Address::generate(&env);
-
-        assert!(!client.paused());
-        client.do_action(&user);
-
-        client.pause(&admin);
-        assert!(client.paused());
-        assert!(client.try_do_action(&user).is_err());
-
-        client.unpause(&admin);
-        assert!(!client.paused());
-        client.do_action(&user);
     }
 }

--- a/contracts/pause-toggle-contract/src/test.rs
+++ b/contracts/pause-toggle-contract/src/test.rs
@@ -1,21 +1,643 @@
+// Copyright (c) 2026 StellarDevTools
+// SPDX-License-Identifier: MIT
+
+//! Comprehensive test suite for the Pause Toggle contract.
+//!
+//! Covers: initialization, pause, unpause, get_pause_reason,
+//! get_pause_timestamp, do_action guards, error codes, and full
+//! lifecycle cycles.
+
 #![cfg(test)]
 
-use super::*;
-use soroban_sdk::{vec, Env, String};
+use soroban_sdk::{testutils::Address as _, Address, Env, String};
+
+use crate::{Error, PauseToggle, PauseToggleClient};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Deploy and initialize in one step; returns (env, admin, client).
+fn setup() -> (Env, Address, PauseToggleClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(PauseToggle, ());
+    let client = PauseToggleClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+    let env = std::boxed::Box::leak(std::boxed::Box::new(env));
+    let client = PauseToggleClient::new(env, &id);
+    (env.clone(), admin, client)
+}
+
+/// Advance ledger timestamp by `delta` seconds.
+fn advance_time(env: &Env, delta: u64) {
+    env.ledger().with_mut(|l| l.timestamp += delta);
+}
+
+fn make_str(env: &Env, s: &str) -> String {
+    String::from_str(env, s)
+}
+
+// ── init ──────────────────────────────────────────────────────────────────────
 
 #[test]
-fn test() {
+fn init_sets_admin() {
     let env = Env::default();
-    let contract_id = env.register(Contract, ());
-    let client = ContractClient::new(&env, &contract_id);
+    env.mock_all_auths();
+    let id = env.register(PauseToggle, ());
+    let client = PauseToggleClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+    assert_eq!(client.get_admin(), admin);
+}
 
-    let words = client.hello(&String::from_str(&env, "Dev"));
+#[test]
+fn init_starts_unpaused() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(PauseToggle, ());
+    let client = PauseToggleClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+    assert!(!client.paused());
+}
+
+#[test]
+fn init_pause_reason_is_none_after_init() {
+    let (_, _, client) = setup();
+    assert!(client.get_pause_reason().is_none());
+}
+
+#[test]
+fn init_pause_timestamp_is_none_after_init() {
+    let (_, _, client) = setup();
+    assert!(client.get_pause_timestamp().is_none());
+}
+
+#[test]
+#[should_panic(expected = "already initialized")]
+fn init_twice_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(PauseToggle, ());
+    let client = PauseToggleClient::new(&env, &id);
+    let admin = Address::generate(&env);
+    client.init(&admin);
+    client.init(&admin);
+}
+
+#[test]
+#[should_panic(expected = "already initialized")]
+fn init_twice_different_admin_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(PauseToggle, ());
+    let client = PauseToggleClient::new(&env, &id);
+    let admin1 = Address::generate(&env);
+    let admin2 = Address::generate(&env);
+    client.init(&admin1);
+    client.init(&admin2);
+}
+
+// ── pause ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn pause_sets_paused_flag() {
+    let (_, admin, client) = setup();
+    client.pause(&admin, &None);
+    assert!(client.paused());
+}
+
+#[test]
+fn pause_without_reason_stores_none() {
+    let (_, admin, client) = setup();
+    client.pause(&admin, &None);
+    assert!(client.get_pause_reason().is_none());
+}
+
+#[test]
+fn pause_with_reason_stores_reason() {
+    let (env, admin, client) = setup();
+    let reason = make_str(&env, "security vulnerability discovered");
+    client.pause(&admin, &Some(reason.clone()));
+    assert_eq!(client.get_pause_reason(), Some(reason));
+}
+
+#[test]
+fn pause_stores_timestamp() {
+    let (env, admin, client) = setup();
+    advance_time(&env, 500);
+    let before = env.ledger().timestamp();
+    client.pause(&admin, &None);
+    let ts = client.get_pause_timestamp().unwrap();
+    assert_eq!(ts, before);
+}
+
+#[test]
+fn pause_timestamp_reflects_ledger_time() {
+    let (env, admin, client) = setup();
+    advance_time(&env, 1_000);
+    client.pause(&admin, &None);
+    assert_eq!(client.get_pause_timestamp().unwrap(), env.ledger().timestamp());
+}
+
+#[test]
+fn pause_by_non_admin_returns_unauthorized() {
+    let (env, _, client) = setup();
+    let stranger = Address::generate(&env);
+    let result = client.try_pause(&stranger, &None);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn pause_already_paused_returns_already_in_state() {
+    let (_, admin, client) = setup();
+    client.pause(&admin, &None);
+    let result = client.try_pause(&admin, &None);
+    assert_eq!(result, Err(Ok(Error::AlreadyInState)));
+}
+
+#[test]
+fn pause_on_uninitialized_returns_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(PauseToggle, ());
+    let client = PauseToggleClient::new(&env, &id);
+    let caller = Address::generate(&env);
+    let result = client.try_pause(&caller, &None);
+    assert_eq!(result, Err(Ok(Error::NotInitialized)));
+}
+
+#[test]
+fn pause_with_empty_reason_stores_empty_string() {
+    let (env, admin, client) = setup();
+    let empty = make_str(&env, "");
+    client.pause(&admin, &Some(empty.clone()));
+    assert_eq!(client.get_pause_reason(), Some(empty));
+}
+
+#[test]
+fn pause_with_long_reason_stores_full_string() {
+    let (env, admin, client) = setup();
+    let long_reason = make_str(&env, "critical exploit found in transfer logic causing double-spend under edge conditions");
+    client.pause(&admin, &Some(long_reason.clone()));
+    assert_eq!(client.get_pause_reason(), Some(long_reason));
+}
+
+// ── unpause ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn unpause_clears_paused_flag() {
+    let (_, admin, client) = setup();
+    client.pause(&admin, &None);
+    client.unpause(&admin);
+    assert!(!client.paused());
+}
+
+#[test]
+fn unpause_clears_pause_reason() {
+    let (env, admin, client) = setup();
+    client.pause(&admin, &Some(make_str(&env, "reason")));
+    client.unpause(&admin);
+    assert!(client.get_pause_reason().is_none());
+}
+
+#[test]
+fn unpause_clears_pause_timestamp() {
+    let (_, admin, client) = setup();
+    client.pause(&admin, &None);
+    client.unpause(&admin);
+    assert!(client.get_pause_timestamp().is_none());
+}
+
+#[test]
+fn unpause_by_non_admin_returns_unauthorized() {
+    let (env, admin, client) = setup();
+    client.pause(&admin, &None);
+    let stranger = Address::generate(&env);
+    let result = client.try_unpause(&stranger);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+}
+
+#[test]
+fn unpause_already_unpaused_returns_already_in_state() {
+    let (_, admin, client) = setup();
+    let result = client.try_unpause(&admin);
+    assert_eq!(result, Err(Ok(Error::AlreadyInState)));
+}
+
+#[test]
+fn unpause_on_uninitialized_returns_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(PauseToggle, ());
+    let client = PauseToggleClient::new(&env, &id);
+    let caller = Address::generate(&env);
+    let result = client.try_unpause(&caller);
+    assert_eq!(result, Err(Ok(Error::NotInitialized)));
+}
+
+#[test]
+fn unpause_state_is_idempotent_when_called_twice() {
+    let (_, admin, client) = setup();
+    client.pause(&admin, &None);
+    client.unpause(&admin);
+    // second unpause should error
+    let result = client.try_unpause(&admin);
+    assert_eq!(result, Err(Ok(Error::AlreadyInState)));
+}
+
+// ── get_pause_reason ──────────────────────────────────────────────────────────
+
+#[test]
+fn get_pause_reason_none_when_not_paused() {
+    let (_, _, client) = setup();
+    assert!(client.get_pause_reason().is_none());
+}
+
+#[test]
+fn get_pause_reason_returns_reason_when_paused_with_reason() {
+    let (env, admin, client) = setup();
+    let r = make_str(&env, "emergency");
+    client.pause(&admin, &Some(r.clone()));
+    assert_eq!(client.get_pause_reason(), Some(r));
+}
+
+#[test]
+fn get_pause_reason_none_when_paused_without_reason() {
+    let (_, admin, client) = setup();
+    client.pause(&admin, &None);
+    assert!(client.get_pause_reason().is_none());
+}
+
+#[test]
+fn get_pause_reason_clears_after_unpause() {
+    let (env, admin, client) = setup();
+    client.pause(&admin, &Some(make_str(&env, "test")));
+    client.unpause(&admin);
+    assert!(client.get_pause_reason().is_none());
+}
+
+#[test]
+fn get_pause_reason_updated_on_re_pause() {
+    let (env, admin, client) = setup();
+    client.pause(&admin, &Some(make_str(&env, "first pause")));
+    client.unpause(&admin);
+    client.pause(&admin, &Some(make_str(&env, "second pause")));
     assert_eq!(
-        words,
-        vec![
-            &env,
-            String::from_str(&env, "Hello"),
-            String::from_str(&env, "Dev"),
-        ]
+        client.get_pause_reason(),
+        Some(make_str(&env, "second pause"))
     );
+}
+
+#[test]
+fn get_pause_reason_none_after_re_pause_without_reason() {
+    let (env, admin, client) = setup();
+    client.pause(&admin, &Some(make_str(&env, "first")));
+    client.unpause(&admin);
+    client.pause(&admin, &None);
+    assert!(client.get_pause_reason().is_none());
+}
+
+// ── get_pause_timestamp ───────────────────────────────────────────────────────
+
+#[test]
+fn get_pause_timestamp_none_before_pause() {
+    let (_, _, client) = setup();
+    assert!(client.get_pause_timestamp().is_none());
+}
+
+#[test]
+fn get_pause_timestamp_set_on_pause() {
+    let (env, admin, client) = setup();
+    advance_time(&env, 100);
+    client.pause(&admin, &None);
+    assert!(client.get_pause_timestamp().is_some());
+}
+
+#[test]
+fn get_pause_timestamp_matches_ledger_at_pause_time() {
+    let (env, admin, client) = setup();
+    advance_time(&env, 999);
+    let expected = env.ledger().timestamp();
+    client.pause(&admin, &None);
+    assert_eq!(client.get_pause_timestamp(), Some(expected));
+}
+
+#[test]
+fn get_pause_timestamp_none_after_unpause() {
+    let (_, admin, client) = setup();
+    client.pause(&admin, &None);
+    client.unpause(&admin);
+    assert!(client.get_pause_timestamp().is_none());
+}
+
+#[test]
+fn get_pause_timestamp_updates_on_re_pause() {
+    let (env, admin, client) = setup();
+    advance_time(&env, 100);
+    client.pause(&admin, &None);
+    let first_ts = client.get_pause_timestamp().unwrap();
+    client.unpause(&admin);
+    advance_time(&env, 500);
+    client.pause(&admin, &None);
+    let second_ts = client.get_pause_timestamp().unwrap();
+    assert!(second_ts > first_ts);
+}
+
+#[test]
+fn get_pause_timestamp_zero_at_genesis() {
+    let (env, admin, client) = setup();
+    // ledger timestamp starts at 0 by default
+    let expected = env.ledger().timestamp();
+    client.pause(&admin, &None);
+    assert_eq!(client.get_pause_timestamp(), Some(expected));
+}
+
+// ── get_admin ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn get_admin_returns_set_admin() {
+    let (_, admin, client) = setup();
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn get_admin_on_uninitialized_returns_not_initialized() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(PauseToggle, ());
+    let client = PauseToggleClient::new(&env, &id);
+    let result = client.try_get_admin();
+    assert_eq!(result, Err(Ok(Error::NotInitialized)));
+}
+
+#[test]
+fn get_admin_remains_same_after_pause_unpause() {
+    let (_, admin, client) = setup();
+    client.pause(&admin, &None);
+    client.unpause(&admin);
+    assert_eq!(client.get_admin(), admin);
+}
+
+// ── do_action ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn do_action_succeeds_when_unpaused() {
+    let (env, _, client) = setup();
+    let user = Address::generate(&env);
+    client.do_action(&user);
+}
+
+#[test]
+fn do_action_blocked_when_paused() {
+    let (env, admin, client) = setup();
+    let user = Address::generate(&env);
+    client.pause(&admin, &None);
+    let result = client.try_do_action(&user);
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
+}
+
+#[test]
+fn do_action_succeeds_after_unpause() {
+    let (env, admin, client) = setup();
+    let user = Address::generate(&env);
+    client.pause(&admin, &None);
+    client.unpause(&admin);
+    client.do_action(&user);
+}
+
+#[test]
+fn do_action_blocked_immediately_after_pause() {
+    let (env, admin, client) = setup();
+    let user = Address::generate(&env);
+    client.do_action(&user); // succeeds before pause
+    client.pause(&admin, &None);
+    let result = client.try_do_action(&user);
+    assert_eq!(result, Err(Ok(Error::ContractPaused)));
+}
+
+#[test]
+fn do_action_different_users_all_blocked_when_paused() {
+    let (env, admin, client) = setup();
+    let u1 = Address::generate(&env);
+    let u2 = Address::generate(&env);
+    client.pause(&admin, &None);
+    assert_eq!(
+        client.try_do_action(&u1),
+        Err(Ok(Error::ContractPaused))
+    );
+    assert_eq!(
+        client.try_do_action(&u2),
+        Err(Ok(Error::ContractPaused))
+    );
+}
+
+// ── Full lifecycle cycles ─────────────────────────────────────────────────────
+
+#[test]
+fn full_pause_unpause_cycle() {
+    let (env, admin, client) = setup();
+    let user = Address::generate(&env);
+
+    assert!(!client.paused());
+    client.do_action(&user);
+
+    client.pause(&admin, &None);
+    assert!(client.paused());
+    assert!(client.try_do_action(&user).is_err());
+
+    client.unpause(&admin);
+    assert!(!client.paused());
+    client.do_action(&user);
+}
+
+#[test]
+fn multiple_pause_unpause_cycles_work_correctly() {
+    let (env, admin, client) = setup();
+    let user = Address::generate(&env);
+
+    for _ in 0..3 {
+        client.pause(&admin, &None);
+        assert!(client.paused());
+        assert!(client.try_do_action(&user).is_err());
+        client.unpause(&admin);
+        assert!(!client.paused());
+        client.do_action(&user);
+    }
+}
+
+#[test]
+fn reason_and_timestamp_cleared_and_reset_across_cycles() {
+    let (env, admin, client) = setup();
+
+    advance_time(&env, 100);
+    client.pause(&admin, &Some(make_str(&env, "cycle1")));
+    assert_eq!(client.get_pause_reason(), Some(make_str(&env, "cycle1")));
+    let ts1 = client.get_pause_timestamp().unwrap();
+
+    client.unpause(&admin);
+    assert!(client.get_pause_reason().is_none());
+    assert!(client.get_pause_timestamp().is_none());
+
+    advance_time(&env, 200);
+    client.pause(&admin, &Some(make_str(&env, "cycle2")));
+    assert_eq!(client.get_pause_reason(), Some(make_str(&env, "cycle2")));
+    let ts2 = client.get_pause_timestamp().unwrap();
+    assert!(ts2 > ts1);
+}
+
+#[test]
+fn paused_flag_false_at_rest_state() {
+    let (_, _, client) = setup();
+    assert!(!client.paused());
+}
+
+#[test]
+fn admin_can_pause_and_unpause_repeatedly_without_error() {
+    let (_, admin, client) = setup();
+    client.pause(&admin, &None);
+    client.unpause(&admin);
+    client.pause(&admin, &None);
+    client.unpause(&admin);
+    assert!(!client.paused());
+}
+
+#[test]
+fn state_is_consistent_after_many_operations() {
+    let (env, admin, client) = setup();
+    let user = Address::generate(&env);
+
+    for i in 0..5u64 {
+        advance_time(&env, 100);
+        client.pause(&admin, &None);
+        assert!(client.paused());
+        assert_eq!(client.get_pause_timestamp().unwrap(), env.ledger().timestamp());
+        assert!(client.try_do_action(&user).is_err());
+        client.unpause(&admin);
+        assert!(!client.paused());
+        assert!(client.get_pause_timestamp().is_none());
+        client.do_action(&user);
+        let _ = i; // suppress unused warning
+    }
+}
+
+// ── Property: only admin can change state ─────────────────────────────────────
+
+#[test]
+fn non_admin_cannot_pause_even_with_auth() {
+    let (env, _, client) = setup();
+    let attacker = Address::generate(&env);
+    let result = client.try_pause(&attacker, &None);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    assert!(!client.paused());
+}
+
+#[test]
+fn non_admin_cannot_unpause_even_with_auth() {
+    let (env, admin, client) = setup();
+    client.pause(&admin, &None);
+    let attacker = Address::generate(&env);
+    let result = client.try_unpause(&attacker);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    assert!(client.paused()); // still paused
+}
+
+#[test]
+fn pause_blocked_action_leaves_state_unchanged() {
+    let (env, _, client) = setup();
+    let attacker = Address::generate(&env);
+    let _ = client.try_pause(&attacker, &None);
+    assert!(!client.paused());
+    assert!(client.get_pause_reason().is_none());
+    assert!(client.get_pause_timestamp().is_none());
+}
+
+// ── Additional coverage ───────────────────────────────────────────────────────
+
+#[test]
+fn paused_query_is_false_initially() {
+    let (_, _, client) = setup();
+    assert_eq!(client.paused(), false);
+}
+
+#[test]
+fn paused_query_is_true_after_pause() {
+    let (_, admin, client) = setup();
+    client.pause(&admin, &None);
+    assert_eq!(client.paused(), true);
+}
+
+#[test]
+fn paused_query_is_false_after_unpause() {
+    let (_, admin, client) = setup();
+    client.pause(&admin, &None);
+    client.unpause(&admin);
+    assert_eq!(client.paused(), false);
+}
+
+#[test]
+fn pause_reason_special_characters_stored_correctly() {
+    let (env, admin, client) = setup();
+    let r = make_str(&env, "exploit: reentrancy in fn transfer()");
+    client.pause(&admin, &Some(r.clone()));
+    assert_eq!(client.get_pause_reason(), Some(r));
+}
+
+#[test]
+fn pause_does_not_change_admin() {
+    let (_, admin, client) = setup();
+    client.pause(&admin, &None);
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn unpause_does_not_change_admin() {
+    let (_, admin, client) = setup();
+    client.pause(&admin, &None);
+    client.unpause(&admin);
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn non_admin_pause_does_not_mutate_paused_state() {
+    let (env, _, client) = setup();
+    let attacker = Address::generate(&env);
+    let _ = client.try_pause(&attacker, &None);
+    // state must be unchanged
+    assert!(!client.paused());
+    assert!(client.get_pause_reason().is_none());
+    assert!(client.get_pause_timestamp().is_none());
+}
+
+#[test]
+fn non_admin_unpause_does_not_mutate_paused_state() {
+    let (env, admin, client) = setup();
+    client.pause(&admin, &Some(make_str(&env, "test")));
+    let attacker = Address::generate(&env);
+    let _ = client.try_unpause(&attacker);
+    // state must be unchanged
+    assert!(client.paused());
+    assert_eq!(
+        client.get_pause_reason(),
+        Some(make_str(&env, "test"))
+    );
+}
+
+#[test]
+fn get_pause_reason_on_uninitialized_returns_none() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(PauseToggle, ());
+    let client = PauseToggleClient::new(&env, &id);
+    // No init called — get_pause_reason should still return None (no panic)
+    assert!(client.get_pause_reason().is_none());
+}
+
+#[test]
+fn get_pause_timestamp_on_uninitialized_returns_none() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register(PauseToggle, ());
+    let client = PauseToggleClient::new(&env, &id);
+    assert!(client.get_pause_timestamp().is_none());
 }


### PR DESCRIPTION
Closes #608

## Summary
Implements a production-ready pause toggle contract with emergency circuit-breaker capabilities.

## Changes

### Smart Contract
- `pause(caller, reason?)` — pause with optional on-chain reason
- `unpause(caller)` — resume and clear audit data
- `get_pause_reason()` — retrieve why the contract was paused
- `get_pause_timestamp()` — retrieve ledger timestamp of last pause
- Admin-only control via `require_auth()`, events emitted for all state changes

### Tests (62 cases)
- init, pause, unpause, audit queries, guarded actions, full lifecycle cycles, property tests

### Backend
- `pauseToggleService.js` + `pauseToggle.js` — 7 REST endpoints at `/api/pause-toggle` with OpenAPI docs and Redis caching

### Documentation
- Full README with interface table, error codes, events, security patterns, deploy guide, API reference