### PR TITLE
feat: add contract storage browser

### DIFF
--- a/backend/src/routes/storage.js
+++ b/backend/src/routes/storage.js
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 StellarDevTools
+// SPDX-License-Identifier: MIT
+
+import express from 'express';
+import { spawn } from 'child_process';
+
+const router = express.Router();
+
+const CONTRACT_ID_RE = /^C[A-Z2-7]{55}$/;
+const NETWORK_RE = /^(testnet|mainnet|futurenet|standalone)$/;
+
+function validateContractId(id) {
+  return typeof id === 'string' && CONTRACT_ID_RE.test(id);
+}
+
+/**
+ * Runs `stellar contract read` and returns parsed storage entries.
+ */
+function readContractStorage(contractId, network = 'testnet') {
+  return new Promise((resolve, reject) => {
+    const args = [
+      'contract',
+      'read',
+      '--id',
+      contractId,
+      '--network',
+      network,
+      '--output',
+      'json',
+    ];
+
+    const child = spawn('stellar', args, {
+      timeout: 30000,
+      env: { ...process.env },
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk) => { stdout += chunk.toString(); });
+    child.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
+
+    child.on('error', (err) => reject(new Error(`stellar CLI error: ${err.message}`)));
+
+    child.on('close', (code) => {
+      if (code !== 0) {
+        return reject(new Error(stderr.trim() || `stellar exited with code ${code}`));
+      }
+      try {
+        // stellar contract read --output json returns one JSON object per line
+        const entries = stdout
+          .split('\n')
+          .filter((line) => line.trim())
+          .map((line) => JSON.parse(line));
+        resolve(entries);
+      } catch {
+        reject(new Error(`Failed to parse stellar output: ${stdout.slice(0, 200)}`));
+      }
+    });
+  });
+}
+
+/**
+ * Detect the data type of a parsed SCVal value.
+ */
+function detectType(value) {
+  if (value === null || value === undefined) return 'null';
+  if (typeof value === 'boolean') return 'bool';
+  if (typeof value === 'number') return 'number';
+  if (typeof value === 'string') {
+    if (/^G[A-Z2-7]{55}$/.test(value) || /^C[A-Z2-7]{55}$/.test(value)) return 'address';
+    if (/^[0-9a-fA-F]+$/.test(value) && value.length % 2 === 0) return 'bytes';
+    if (/^-?\d+$/.test(value)) return 'integer';
+    return 'string';
+  }
+  if (Array.isArray(value)) return 'vec';
+  if (typeof value === 'object') {
+    if ('type' in value) return value.type;
+    return 'map';
+  }
+  return 'unknown';
+}
+
+/**
+ * Flatten SCVal entries from stellar contract read output.
+ * Each entry has { key, value } where both are SCVal objects.
+ */
+function flattenEntries(rawEntries) {
+  return rawEntries.map((entry, index) => {
+    const key = entry.key ?? entry.Key ?? entry[0];
+    const value = entry.value ?? entry.Value ?? entry[1];
+    const keyStr = typeof key === 'string' ? key : JSON.stringify(key);
+    return {
+      id: index,
+      key: keyStr,
+      keyRaw: key,
+      value,
+      type: detectType(value),
+    };
+  });
+}
+
+// GET /api/storage/entries?contractId=C...&network=testnet
+router.get('/entries', async (req, res) => {
+  const { contractId, network = 'testnet' } = req.query;
+
+  if (!validateContractId(contractId)) {
+    return res.status(400).json({
+      success: false,
+      error: 'Invalid contractId. Must be a valid Stellar contract address (C...).',
+    });
+  }
+
+  if (!NETWORK_RE.test(network)) {
+    return res.status(400).json({
+      success: false,
+      error: 'Invalid network. Must be one of: testnet, mainnet, futurenet, standalone.',
+    });
+  }
+
+  try {
+    const raw = await readContractStorage(contractId, network);
+    const entries = flattenEntries(raw);
+    return res.json({ success: true, data: { contractId, network, entries, count: entries.length } });
+  } catch (err) {
+    const message = err.message ?? 'Unknown error reading contract storage';
+    // Distinguish "contract not found" vs other errors
+    const status = message.includes('not found') || message.includes('does not exist') ? 404 : 500;
+    return res.status(status).json({ success: false, error: message });
+  }
+});
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -27,6 +27,7 @@ import migrationRoute from './routes/migration.js';
 import sportsPredictionMarketRoute from './routes/sportsPredictionMarket.js';
 import tokenizedReitRoute from './routes/tokenizedReit.js';
 import treasuryRoute from './routes/treasury.js';
+import storageRoute from './routes/storage.js';
 import { initializeDatabase } from './database/connection.js';
 import { setupGraphQL } from './graphql/index.js';
 
@@ -91,6 +92,7 @@ app.use('/api/migrations', migrationRoute);
 app.use('/api/sports-markets', sportsPredictionMarketRoute);
 app.use('/api/reit', tokenizedReitRoute);
 app.use('/api/treasury', treasuryRoute);
+app.use('/api/storage', storageRoute);
 app.use('/metrics', metricsRoute);
 
 // GraphQL Endpoint

--- a/frontend/src/app/storage-browser/page.tsx
+++ b/frontend/src/app/storage-browser/page.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+// Copyright (c) 2026 StellarDevTools
+// SPDX-License-Identifier: MIT
+
+import React, { useState, useCallback, useMemo } from "react";
+import { Database, RefreshCw, Download } from "lucide-react";
+import StorageTree from "@/components/StorageTree";
+import StorageSearchBar from "@/components/StorageSearchBar";
+import type { StorageEntry } from "@/components/StorageTree";
+import type { StorageDataType } from "@/components/DataTypeFormatter";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:5000";
+
+const NETWORKS = ["testnet", "mainnet", "futurenet", "standalone"] as const;
+type Network = (typeof NETWORKS)[number];
+
+function exportJson(entries: StorageEntry[], contractId: string) {
+  const blob = new Blob([JSON.stringify(entries, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `storage-${contractId.slice(0, 8)}.json`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function exportCsv(entries: StorageEntry[], contractId: string) {
+  const rows = [
+    ["id", "key", "type", "value"],
+    ...entries.map((e) => [
+      String(e.id),
+      e.key,
+      e.type,
+      typeof e.value === "string" ? e.value : JSON.stringify(e.value),
+    ]),
+  ];
+  const csv = rows.map((r) => r.map((c) => `"${c.replace(/"/g, '""')}"`).join(",")).join("\n");
+  const blob = new Blob([csv], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `storage-${contractId.slice(0, 8)}.csv`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export default function StorageBrowserPage() {
+  const [contractId, setContractId] = useState("");
+  const [network, setNetwork] = useState<Network>("testnet");
+  const [entries, setEntries] = useState<StorageEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [loadedContract, setLoadedContract] = useState("");
+
+  // Search / filter state
+  const [query, setQuery] = useState("");
+  const [typeFilter, setTypeFilter] = useState<StorageDataType | "">("");
+
+  const fetchEntries = useCallback(async () => {
+    const id = contractId.trim();
+    if (!id) return;
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch(
+        `${API_BASE}/api/storage/entries?contractId=${encodeURIComponent(id)}&network=${network}`
+      );
+      const data = await res.json();
+      if (!data.success) throw new Error(data.error);
+      setEntries(data.data.entries);
+      setLoadedContract(id);
+      setQuery("");
+      setTypeFilter("");
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : "Failed to fetch storage");
+      setEntries([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [contractId, network]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") fetchEntries();
+  };
+
+  const filteredEntries = useMemo(() => {
+    return entries.filter((entry) => {
+      if (typeFilter && entry.type !== typeFilter) return false;
+      if (!query) return true;
+      const q = query.toLowerCase();
+      const valueStr =
+        typeof entry.value === "string"
+          ? entry.value.toLowerCase()
+          : JSON.stringify(entry.value).toLowerCase();
+      return entry.key.toLowerCase().includes(q) || valueStr.includes(q);
+    });
+  }, [entries, query, typeFilter]);
+
+  return (
+    <main className="min-h-screen bg-[#060c18] text-slate-200 p-4 md:p-8">
+      <div className="max-w-5xl mx-auto space-y-5">
+        {/* Header */}
+        <div className="flex items-center gap-3">
+          <div className="p-2 rounded-xl bg-teal-500/10 border border-teal-500/20">
+            <Database size={20} className="text-teal-400" />
+          </div>
+          <div>
+            <h1 className="text-lg font-semibold text-white">Storage Browser</h1>
+            <p className="text-xs text-slate-500">
+              Inspect and explore contract ledger storage entries
+            </p>
+          </div>
+        </div>
+
+        {/* Query bar */}
+        <div className="flex gap-2 flex-wrap">
+          <input
+            type="text"
+            placeholder="Contract ID (C…)"
+            value={contractId}
+            onChange={(e) => setContractId(e.target.value)}
+            onKeyDown={handleKeyDown}
+            className="flex-1 min-w-0 bg-slate-800/70 text-slate-200 text-sm rounded-xl px-4 py-2.5 placeholder-slate-500 border border-slate-700/60 focus:outline-none focus:ring-1 focus:ring-teal-500/60 font-mono transition-colors"
+            aria-label="Contract ID"
+          />
+          <select
+            value={network}
+            onChange={(e) => setNetwork(e.target.value as Network)}
+            className="bg-slate-800/70 text-slate-200 text-sm rounded-xl px-3 py-2.5 border border-slate-700/60 focus:outline-none focus:ring-1 focus:ring-teal-500/60 transition-colors"
+            aria-label="Network"
+          >
+            {NETWORKS.map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={fetchEntries}
+            disabled={loading || !contractId.trim()}
+            className="flex items-center gap-2 bg-teal-600 hover:bg-teal-500 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm px-4 py-2.5 rounded-xl transition-colors font-medium"
+            aria-label="Load storage"
+          >
+            <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+            {loading ? "Loading…" : "Load"}
+          </button>
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div
+            className="bg-rose-900/25 border border-rose-700/50 text-rose-300 text-xs rounded-xl px-4 py-3"
+            role="alert"
+          >
+            {error}
+          </div>
+        )}
+
+        {/* Results section */}
+        {loadedContract && (
+          <div className="space-y-3">
+            {/* Toolbar */}
+            <div className="flex items-center justify-between gap-3 flex-wrap">
+              <div className="flex-1 min-w-0">
+                <StorageSearchBar
+                  query={query}
+                  onQueryChange={setQuery}
+                  typeFilter={typeFilter}
+                  onTypeFilterChange={setTypeFilter}
+                  resultCount={filteredEntries.length}
+                  totalCount={entries.length}
+                />
+              </div>
+              {/* Export buttons */}
+              {entries.length > 0 && (
+                <div className="flex items-center gap-2 shrink-0">
+                  <button
+                    onClick={() => exportJson(filteredEntries, loadedContract)}
+                    className="flex items-center gap-1.5 text-xs text-slate-400 hover:text-slate-200 bg-slate-800/60 hover:bg-slate-700/60 border border-slate-700/50 px-3 py-1.5 rounded-lg transition-colors"
+                    title="Export as JSON"
+                  >
+                    <Download size={12} />
+                    JSON
+                  </button>
+                  <button
+                    onClick={() => exportCsv(filteredEntries, loadedContract)}
+                    className="flex items-center gap-1.5 text-xs text-slate-400 hover:text-slate-200 bg-slate-800/60 hover:bg-slate-700/60 border border-slate-700/50 px-3 py-1.5 rounded-lg transition-colors"
+                    title="Export as CSV"
+                  >
+                    <Download size={12} />
+                    CSV
+                  </button>
+                </div>
+              )}
+            </div>
+
+            {/* Info pill */}
+            <div className="flex items-center gap-2 text-[11px] text-slate-500">
+              <span className="font-mono text-slate-400">{loadedContract.slice(0, 10)}…</span>
+              <span>·</span>
+              <span>{network}</span>
+              <span>·</span>
+              <span>{entries.length} entries</span>
+            </div>
+
+            {/* Storage tree */}
+            <StorageTree entries={filteredEntries} />
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!loadedContract && !loading && !error && (
+          <div className="flex flex-col items-center justify-center py-16 text-center text-slate-600 space-y-2">
+            <Database size={36} className="opacity-30" />
+            <p className="text-sm">Enter a contract ID to browse its storage</p>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/DataTypeFormatter.tsx
+++ b/frontend/src/components/DataTypeFormatter.tsx
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 StellarDevTools
+// SPDX-License-Identifier: MIT
+
+import React, { useState } from "react";
+
+export type StorageDataType =
+  | "address"
+  | "bytes"
+  | "integer"
+  | "number"
+  | "bool"
+  | "string"
+  | "vec"
+  | "map"
+  | "null"
+  | "unknown"
+  | string;
+
+interface DataTypeFormatterProps {
+  value: unknown;
+  type: StorageDataType;
+  /** If true, renders a compact badge-style version of the type label */
+  showBadge?: boolean;
+}
+
+const TYPE_COLORS: Record<string, string> = {
+  address: "text-sky-300 bg-sky-950/50 border-sky-800/60",
+  bytes: "text-violet-300 bg-violet-950/50 border-violet-800/60",
+  integer: "text-amber-300 bg-amber-950/50 border-amber-800/60",
+  number: "text-amber-300 bg-amber-950/50 border-amber-800/60",
+  bool: "text-rose-300 bg-rose-950/50 border-rose-800/60",
+  string: "text-emerald-300 bg-emerald-950/50 border-emerald-800/60",
+  vec: "text-cyan-300 bg-cyan-950/50 border-cyan-800/60",
+  map: "text-teal-300 bg-teal-950/50 border-teal-800/60",
+  null: "text-gray-500 bg-gray-900/50 border-gray-800/60",
+  unknown: "text-gray-400 bg-gray-900/50 border-gray-800/60",
+};
+
+function badgeClass(type: StorageDataType): string {
+  return (
+    TYPE_COLORS[type] ??
+    "text-slate-300 bg-slate-900/50 border-slate-700/60"
+  );
+}
+
+function truncate(str: string, maxLen = 80): string {
+  return str.length > maxLen ? `${str.slice(0, maxLen)}…` : str;
+}
+
+function safeStr(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return "[unserializable]";
+  }
+}
+
+function AddressValue({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+  const copy = () => {
+    navigator.clipboard.writeText(value).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+  return (
+    <span className="flex items-center gap-1.5 font-mono text-sky-300">
+      <span title={value}>{`${value.slice(0, 6)}…${value.slice(-4)}`}</span>
+      <button
+        onClick={copy}
+        className="text-[10px] text-slate-500 hover:text-slate-300 transition-colors"
+        title={copied ? "Copied!" : "Copy address"}
+        aria-label={copied ? "Copied!" : "Copy address"}
+      >
+        {copied ? "✓" : "⎘"}
+      </button>
+    </span>
+  );
+}
+
+function BytesValue({ value }: { value: string }) {
+  const byteLen = Math.floor(value.replace(/\s/g, "").length / 2);
+  return (
+    <span className="font-mono text-violet-300" title={value}>
+      {truncate(value, 40)}{" "}
+      <span className="text-[10px] text-slate-500">({byteLen}B)</span>
+    </span>
+  );
+}
+
+export function TypeBadge({ type }: { type: StorageDataType }) {
+  return (
+    <span
+      className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-mono font-semibold border ${badgeClass(type)}`}
+    >
+      {type}
+    </span>
+  );
+}
+
+export default function DataTypeFormatter({
+  value,
+  type,
+  showBadge = false,
+}: DataTypeFormatterProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const renderValue = () => {
+    if (type === "address" && typeof value === "string") {
+      return <AddressValue value={value} />;
+    }
+    if (type === "bytes" && typeof value === "string") {
+      return <BytesValue value={value} />;
+    }
+    if (type === "bool") {
+      return (
+        <span className={value ? "text-emerald-400" : "text-rose-400"}>
+          {String(value)}
+        </span>
+      );
+    }
+    if (type === "null") {
+      return <span className="text-gray-500 italic">null</span>;
+    }
+    if (type === "vec" || type === "map") {
+      const str = safeStr(value);
+      return (
+        <span className="font-mono text-cyan-300">
+          {expanded ? (
+            <>
+              <pre className="whitespace-pre-wrap break-all text-xs">{str}</pre>
+              <button
+                onClick={() => setExpanded(false)}
+                className="text-[10px] text-slate-500 hover:text-slate-300 mt-1"
+              >
+                collapse
+              </button>
+            </>
+          ) : (
+            <>
+              {truncate(str)}{" "}
+              {str.length > 80 && (
+                <button
+                  onClick={() => setExpanded(true)}
+                  className="text-[10px] text-slate-500 hover:text-slate-300"
+                >
+                  expand
+                </button>
+              )}
+            </>
+          )}
+        </span>
+      );
+    }
+    // integer, number, string, unknown
+    const str = safeStr(value);
+    return (
+      <span className="font-mono break-all">
+        {truncate(str)}
+      </span>
+    );
+  };
+
+  return (
+    <span className="inline-flex items-center gap-2 flex-wrap">
+      {showBadge && <TypeBadge type={type} />}
+      {renderValue()}
+    </span>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -67,6 +67,7 @@ export default function SidebarShell({ children }: { children: React.ReactNode }
       items: [
         { name: "IDE Playground", href: "/playground", icon: Code2 },
         { name: "Compile Dashboard", href: "/compile-dashboard", icon: Zap },
+        { name: "Storage Browser", href: "/storage-browser", icon: Database },
         { name: "Docs & Reference", href: "/docs", icon: BookOpen },
         { name: "Audit Explorer", href: "/audit", icon: Shield },
         { name: "Search Utility", href: "/search", icon: Search },

--- a/frontend/src/components/StorageSearchBar.tsx
+++ b/frontend/src/components/StorageSearchBar.tsx
@@ -1,0 +1,98 @@
+// Copyright (c) 2026 StellarDevTools
+// SPDX-License-Identifier: MIT
+
+import React from "react";
+import { Search, X } from "lucide-react";
+import { TypeBadge } from "./DataTypeFormatter";
+import type { StorageDataType } from "./DataTypeFormatter";
+
+export const DATA_TYPES: StorageDataType[] = [
+  "address",
+  "bytes",
+  "integer",
+  "number",
+  "bool",
+  "string",
+  "vec",
+  "map",
+];
+
+interface StorageSearchBarProps {
+  query: string;
+  onQueryChange: (q: string) => void;
+  typeFilter: StorageDataType | "";
+  onTypeFilterChange: (t: StorageDataType | "") => void;
+  resultCount: number;
+  totalCount: number;
+}
+
+export default function StorageSearchBar({
+  query,
+  onQueryChange,
+  typeFilter,
+  onTypeFilterChange,
+  resultCount,
+  totalCount,
+}: StorageSearchBarProps) {
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+      {/* Text search */}
+      <div className="relative flex-1">
+        <Search
+          size={14}
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500 pointer-events-none"
+        />
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          placeholder="Search keys or values…"
+          className="w-full bg-slate-800/70 text-slate-200 text-xs rounded-lg pl-8 pr-8 py-2 placeholder-slate-500 border border-slate-700/60 focus:outline-none focus:ring-1 focus:ring-teal-500/60 transition-colors"
+          aria-label="Search storage entries"
+        />
+        {query && (
+          <button
+            onClick={() => onQueryChange("")}
+            className="absolute right-2.5 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300 transition-colors"
+            aria-label="Clear search"
+          >
+            <X size={12} />
+          </button>
+        )}
+      </div>
+
+      {/* Type filter */}
+      <div className="flex items-center gap-1.5 flex-wrap">
+        <button
+          onClick={() => onTypeFilterChange("")}
+          className={`px-2.5 py-1 rounded-lg text-[10px] font-semibold border transition-colors ${
+            typeFilter === ""
+              ? "bg-teal-500/15 border-teal-500/40 text-teal-300"
+              : "bg-slate-800/50 border-slate-700/50 text-slate-400 hover:text-slate-200"
+          }`}
+          aria-pressed={typeFilter === ""}
+        >
+          All
+        </button>
+        {DATA_TYPES.map((t) => (
+          <button
+            key={t}
+            onClick={() => onTypeFilterChange(typeFilter === t ? "" : t)}
+            className={`transition-opacity ${typeFilter !== "" && typeFilter !== t ? "opacity-50" : ""}`}
+            aria-pressed={typeFilter === t}
+            title={`Filter by ${t}`}
+          >
+            <TypeBadge type={t} />
+          </button>
+        ))}
+      </div>
+
+      {/* Result count */}
+      {(query || typeFilter) && (
+        <span className="text-[10px] text-slate-500 whitespace-nowrap shrink-0">
+          {resultCount} / {totalCount}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/StorageTree.tsx
+++ b/frontend/src/components/StorageTree.tsx
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 StellarDevTools
+// SPDX-License-Identifier: MIT
+
+import React, { useState } from "react";
+import { ChevronRight, ChevronDown } from "lucide-react";
+import DataTypeFormatter, { TypeBadge } from "./DataTypeFormatter";
+import type { StorageDataType } from "./DataTypeFormatter";
+
+export interface StorageEntry {
+  id: number;
+  key: string;
+  keyRaw: unknown;
+  value: unknown;
+  type: StorageDataType;
+}
+
+interface StorageTreeProps {
+  entries: StorageEntry[];
+}
+
+/** Recursively render a JSON value as a collapsible tree node */
+function TreeNode({
+  label,
+  value,
+  depth = 0,
+}: {
+  label: string;
+  value: unknown;
+  depth?: number;
+}) {
+  const [open, setOpen] = useState(depth < 2);
+  const isComplex = value !== null && typeof value === "object";
+  const children = isComplex
+    ? Array.isArray(value)
+      ? (value as unknown[]).map((v, i) => ({ key: String(i), val: v }))
+      : Object.entries(value as Record<string, unknown>).map(([k, v]) => ({
+          key: k,
+          val: v,
+        }))
+    : [];
+
+  const indent = depth * 14;
+
+  return (
+    <div style={{ paddingLeft: indent }}>
+      <div className="flex items-start gap-1 py-0.5 group">
+        {isComplex && children.length > 0 ? (
+          <button
+            onClick={() => setOpen((o) => !o)}
+            className="shrink-0 mt-0.5 text-slate-500 hover:text-slate-300 transition-colors"
+            aria-label={open ? "Collapse" : "Expand"}
+          >
+            {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+          </button>
+        ) : (
+          <span className="w-3 shrink-0" />
+        )}
+        <span className="text-slate-400 font-mono text-xs shrink-0">{label}:</span>
+        {isComplex ? (
+          <span className="text-slate-500 text-xs ml-1">
+            {Array.isArray(value) ? `[${children.length}]` : `{${children.length}}`}
+          </span>
+        ) : (
+          <span className="ml-1">
+            <DataTypeFormatter
+              value={value}
+              type={
+                typeof value === "boolean"
+                  ? "bool"
+                  : value === null
+                  ? "null"
+                  : typeof value === "number"
+                  ? "number"
+                  : "string"
+              }
+            />
+          </span>
+        )}
+      </div>
+      {isComplex && open && children.map(({ key, val }) => (
+        <TreeNode key={key} label={key} value={val} depth={depth + 1} />
+      ))}
+    </div>
+  );
+}
+
+function EntryRow({ entry }: { entry: StorageEntry }) {
+  const [expanded, setExpanded] = useState(false);
+  const isComplex =
+    entry.value !== null && typeof entry.value === "object";
+
+  return (
+    <div className="border-b border-slate-800/50 last:border-0">
+      <div
+        className="flex items-start gap-3 px-3 py-2.5 hover:bg-slate-800/30 transition-colors cursor-pointer"
+        onClick={() => isComplex && setExpanded((e) => !e)}
+        role={isComplex ? "button" : undefined}
+        aria-expanded={isComplex ? expanded : undefined}
+      >
+        {/* Expand toggle */}
+        <span className="mt-0.5 shrink-0 text-slate-600 w-3">
+          {isComplex ? (
+            expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />
+          ) : null}
+        </span>
+
+        {/* Key */}
+        <span className="font-mono text-xs text-cyan-300 break-all w-48 shrink-0">
+          {entry.key}
+        </span>
+
+        {/* Type badge */}
+        <span className="shrink-0">
+          <TypeBadge type={entry.type} />
+        </span>
+
+        {/* Value */}
+        <span className="text-xs flex-1 min-w-0">
+          {isComplex && !expanded ? (
+            <span className="text-slate-500 italic">
+              {Array.isArray(entry.value)
+                ? `Array(${(entry.value as unknown[]).length})`
+                : `Object(${Object.keys(entry.value as object).length})`}
+              {" — click to expand"}
+            </span>
+          ) : !isComplex ? (
+            <DataTypeFormatter value={entry.value} type={entry.type} />
+          ) : null}
+        </span>
+      </div>
+
+      {/* Expanded tree */}
+      {expanded && isComplex && (
+        <div className="px-4 pb-3 bg-slate-900/40 border-t border-slate-800/40">
+          {Array.isArray(entry.value)
+            ? (entry.value as unknown[]).map((v, i) => (
+                <TreeNode key={i} label={String(i)} value={v} depth={0} />
+              ))
+            : Object.entries(entry.value as Record<string, unknown>).map(
+                ([k, v]) => <TreeNode key={k} label={k} value={v} depth={0} />
+              )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function StorageTree({ entries }: StorageTreeProps) {
+  if (entries.length === 0) {
+    return (
+      <p className="text-xs text-slate-500 italic text-center py-8">
+        No entries match your search.
+      </p>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-slate-800/60 overflow-hidden bg-slate-900/50">
+      {/* Header row */}
+      <div className="flex items-center gap-3 px-3 py-2 bg-slate-800/40 border-b border-slate-700/40">
+        <span className="w-3 shrink-0" />
+        <span className="font-semibold text-[10px] text-slate-500 uppercase tracking-wider w-48 shrink-0">Key</span>
+        <span className="font-semibold text-[10px] text-slate-500 uppercase tracking-wider shrink-0">Type</span>
+        <span className="font-semibold text-[10px] text-slate-500 uppercase tracking-wider">Value</span>
+      </div>
+      {entries.map((entry) => (
+        <EntryRow key={entry.id} entry={entry} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
feat: Contract Storage Browser
  
  Summary
  
  Adds a full-stack contract storage browser that lets developers visually
  inspect, search, filter, and export the on-chain storage of any deployed
  Soroban smart contract — no CLI required.
  
  Changes
  
  Backend
  
  - backend/src/routes/storage.js — new GET
  /api/storage/entries?contractId=&network= endpoint that shells out to stellar
  contract read --output json, parses entries, and detects data types
  - backend/src/server.js — mounts the route at /api/storage
  
  Frontend
  
  - frontend/src/app/storage-browser/page.tsx — new page at /storage-browser with
  contract ID input, network selector, real-time search, type filtering, and
  JSON/CSV export
  - frontend/src/components/StorageTree.tsx — collapsible tree table; complex
  values (maps, vecs) expand inline
  - frontend/src/components/StorageSearchBar.tsx — text search + type filter chip
  row with live result count
  - frontend/src/components/DataTypeFormatter.tsx — type-aware value rendering
  (address shortening + copy, bytes size label, bool color, expandable objects)
  with reusable TypeBadge
  - frontend/src/components/Sidebar.tsx — added "Storage Browser" nav link under
  Core IDE & Ops
  
  Testing
  
  - Load any deployed testnet contract ID to browse its storage
  - Search by key or value text
  - Click a type badge to filter by data type (address, bytes, integer, bool,
  string, vec, map)
  - Export filtered results as JSON or CSV
  
  Related
  
  - Closes #5 (Storage Viewer)
  - No breaking changes
closes #573
