### PR TITLE
Add Swagger/OAS 3.0 documentation generator and interactive /api-docs endpoint

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -31,6 +31,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1",
     "@opentelemetry/api": "^1.8.0",
     "@opentelemetry/auto-instrumentations-node": "^0.52.1",
     "@opentelemetry/exporter-jaeger": "^1.28.0",

--- a/backend/src/docs/swagger.js
+++ b/backend/src/docs/swagger.js
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 StellarDevTools
+// SPDX-License-Identifier: MIT
+
+import swaggerJsdoc from 'swagger-jsdoc';
+import swaggerUi from 'swagger-ui-express';
+
+const options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'Soroban Playground API',
+      version: '1.0.0',
+      description:
+        'REST API for compiling, deploying, and invoking Soroban smart contracts on Stellar.',
+    },
+    servers: [{ url: '/api', description: 'Default server' }],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+      },
+      schemas: {
+        Error: {
+          type: 'object',
+          properties: {
+            error: { type: 'string' },
+            message: { type: 'string' },
+          },
+        },
+      },
+    },
+  },
+  apis: ['./src/routes/**/*.js', './src/docs/*.doc.js'],
+};
+
+export const swaggerSpec = swaggerJsdoc(options);
+
+export function setupSwagger(app) {
+  app.get('/api-docs/spec.json', (_req, res) => {
+    res.setHeader('Content-Type', 'application/json');
+    res.send(swaggerSpec);
+  });
+
+  app.use(
+    '/api-docs',
+    swaggerUi.serve,
+    swaggerUi.setup(swaggerSpec, {
+      customSiteTitle: 'Soroban Playground API Docs',
+      swaggerOptions: {
+        persistAuthorization: true,
+        displayRequestDuration: true,
+        filter: true,
+        tryItOutEnabled: true,
+      },
+    }),
+  );
+}

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -41,6 +41,7 @@ import { compressionMiddleware } from './middleware/compressionMiddleware.js';
 import feeEngineRoute from './routes/feeEngine.js';
 import featureFlagsRoute from './routes/featureFlags.js';
 import featureFlagService from './services/featureFlagService.js';
+import { setupSwagger } from './docs/swagger.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -113,6 +114,7 @@ app.use('/metrics', metricsRoute);
 
 // GraphQL Endpoint
 setupGraphQL(app);
+setupSwagger(app);
 
 // ─── Health Check Helpers ──────────────────────────────────────────────────────
 

--- a/backend/tests/swagger.test.js
+++ b/backend/tests/swagger.test.js
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 StellarDevTools
+// SPDX-License-Identifier: MIT
+
+import { jest } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+
+jest.unstable_mockModule('../src/services/compileService.js', () => ({
+  getCompileStats: jest.fn(),
+  getCompileSnapshot: jest.fn(),
+  initializeCompileService: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/services/redisService.js', () => ({
+  default: { isConnected: false, get: jest.fn(), set: jest.fn() },
+}));
+
+const { setupSwagger, swaggerSpec } = await import('../src/docs/swagger.js');
+
+describe('Swagger / OAS Documentation', () => {
+  let app;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    setupSwagger(app);
+  });
+
+  it('serves the OAS JSON spec at /api-docs/spec.json', async () => {
+    const res = await request(app).get('/api-docs/spec.json');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    const spec = res.body;
+    expect(spec.openapi).toMatch(/^3\./);
+    expect(spec.info.title).toBe('Soroban Playground API');
+  });
+
+  it('serves the Swagger UI HTML at /api-docs', async () => {
+    const res = await request(app).get('/api-docs/');
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/text\/html/);
+    expect(res.text).toContain('swagger');
+  });
+
+  it('spec contains at least one path', () => {
+    expect(swaggerSpec.paths).toBeDefined();
+    expect(Object.keys(swaggerSpec.paths).length).toBeGreaterThan(0);
+  });
+
+  it('spec passes OAS 3.0 structural validation', () => {
+    expect(swaggerSpec.openapi).toBeDefined();
+    expect(swaggerSpec.info).toBeDefined();
+    expect(swaggerSpec.info.version).toBeDefined();
+    expect(swaggerSpec.components).toBeDefined();
+  });
+
+  it('spec includes security scheme definition', () => {
+    expect(swaggerSpec.components?.securitySchemes?.bearerAuth).toBeDefined();
+    expect(swaggerSpec.components.securitySchemes.bearerAuth.type).toBe('http');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `swagger-jsdoc` + `swagger-ui-express` to auto-generate an OpenAPI 3.0 spec from JSDoc `@openapi` annotations already present in route files and `src/docs/*.doc.js`
- Exposes `/api-docs/spec.json` (raw JSON spec) and `/api-docs` (Swagger UI with Try-it-out + JWT auth panel)
- Wires `setupSwagger(app)` into `server.js` alongside the GraphQL setup
- Bearer auth scheme defined in `components.securitySchemes` for routes that require authorization

## Test plan

- [ ] Start the backend and navigate to `http://localhost:5000/api-docs` — Swagger UI should load
- [ ] `GET /api-docs/spec.json` should return a valid OAS 3.0 JSON document
- [ ] All existing `health.doc.js`, `compile.doc.js`, `deploy.doc.js`, `invoke.doc.js` JSDoc entries should appear in the spec
- [ ] `npm test tests/swagger.test.js` passes (5 tests)

Closes StellarDevHub/soroban-playground#741