### PR TITLE
[#732] [BACKEND] SQL Injection Prevention Audit & Prepared Statement Guardrails

### DIFF
--- a/backend/eslint-rules/no-unsafe-sql-literal.js
+++ b/backend/eslint-rules/no-unsafe-sql-literal.js
@@ -1,0 +1,43 @@
+/**
+ * ESLint rule: disallow dynamic SQL string interpolation outside allowlisted maps.
+ */
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow template literal interpolation inside SQL-looking strings',
+    },
+    schema: [],
+    messages: {
+      unsafeSql:
+        'Avoid embedding expressions in SQL strings. Use bound parameters (?) instead.',
+    },
+  },
+  create(context) {
+    function checkTemplateLiteral(node) {
+      if (!node.expressions || node.expressions.length === 0) return;
+
+      const quasiText = node.quasis.map((q) => q.value.raw).join(' ');
+      const looksLikeSql =
+        /\b(SELECT|INSERT|UPDATE|DELETE|FROM|WHERE|ORDER BY)\b/i.test(
+          quasiText
+        );
+      if (!looksLikeSql) return;
+
+      const isAllowlistedSortMap =
+        /sortMapping|ORDER_OPTIONS|SORT_OPTIONS|sortOptions/i.test(
+          context.getSourceCode().getText(node.parent || node)
+        );
+      if (isAllowlistedSortMap) return;
+
+      context.report({ node, messageId: 'unsafeSql' });
+    }
+
+    return {
+      TemplateLiteral: checkTemplateLiteral,
+    };
+  },
+};
+
+export default rule;

--- a/backend/eslint.config.js
+++ b/backend/eslint.config.js
@@ -2,20 +2,27 @@ import prettierPlugin from 'eslint-plugin-prettier';
 import prettierConfig from 'eslint-config-prettier';
 import tsParser from '@typescript-eslint/parser';
 import tsPlugin from '@typescript-eslint/eslint-plugin';
+import noUnsafeSqlLiteral from './eslint-rules/no-unsafe-sql-literal.js';
 
 export default [
   {
     // JavaScript files
     files: ['**/*.js', '**/*.cjs', '**/*.mjs'],
-    ignores: ['node_modules', 'dist', 'build'],
+    ignores: ['node_modules', 'dist', 'build', 'eslint-rules/**'],
     plugins: {
       prettier: prettierPlugin,
+      'sql-security': {
+        rules: {
+          'no-unsafe-sql-literal': noUnsafeSqlLiteral,
+        },
+      },
     },
     rules: {
       ...prettierConfig.rules,
       'prettier/prettier': 'error',
       'no-unused-vars': 'off',
       'no-console': 'off',
+      'sql-security/no-unsafe-sql-literal': 'warn',
     },
     languageOptions: {
       ecmaVersion: 'latest',

--- a/backend/src/database/connection.js
+++ b/backend/src/database/connection.js
@@ -45,53 +45,69 @@ async function openDatabase(options = {}) {
   await handle.run('PRAGMA synchronous = NORMAL');
 
   // Query Profiling & Slow Query Logging
-  const thresholdMs = process.env.SLOW_QUERY_THRESHOLD_MS ? parseInt(process.env.SLOW_QUERY_THRESHOLD_MS, 10) : 50;
+  const thresholdMs = process.env.SLOW_QUERY_THRESHOLD_MS
+    ? parseInt(process.env.SLOW_QUERY_THRESHOLD_MS, 10)
+    : 50;
   const methodsToWrap = ['run', 'get', 'all', 'exec'];
-  
-  methodsToWrap.forEach(method => {
+
+  methodsToWrap.forEach((method) => {
     const original = handle[method].bind(handle);
-    handle[method] = async function(...args) {
+    handle[method] = async function (...args) {
       const startTime = process.hrtime.bigint();
       const traceId = Math.random().toString(36).substring(2, 15);
-      
+
       try {
         return await original(...args);
       } finally {
         const endTime = process.hrtime.bigint();
         const durationMs = Number(endTime - startTime) / 1000000;
-        
+
         if (durationMs > thresholdMs) {
           const query = args[0];
           const params = args.slice(1);
-          
-          console.warn(JSON.stringify({
-            level: 'warn',
-            message: 'Slow query detected',
-            traceId,
-            durationMs,
-            query: typeof query === 'string' ? query : 'unknown',
-            params
-          }));
-          
-          if (typeof query === 'string' && query.trim().toUpperCase().match(/^(SELECT|UPDATE|DELETE|INSERT)/)) {
-             try {
-               const plan = await original(`EXPLAIN QUERY PLAN ${query}`, ...params);
-               console.warn(JSON.stringify({
-                 level: 'warn',
-                 message: 'Slow query plan',
-                 traceId,
-                 plan
-               }));
-             } catch (e) {
-               // ignore
-             }
+
+          console.warn(
+            JSON.stringify({
+              level: 'warn',
+              message: 'Slow query detected',
+              traceId,
+              durationMs,
+              query: typeof query === 'string' ? query : 'unknown',
+              params,
+            })
+          );
+
+          if (
+            typeof query === 'string' &&
+            query
+              .trim()
+              .toUpperCase()
+              .match(/^(SELECT|UPDATE|DELETE|INSERT)/)
+          ) {
+            try {
+              const plan = await original(
+                `EXPLAIN QUERY PLAN ${query}`,
+                ...params
+              );
+              console.warn(
+                JSON.stringify({
+                  level: 'warn',
+                  message: 'Slow query plan',
+                  traceId,
+                  plan,
+                })
+              );
+            } catch (e) {
+              // ignore
+            }
           }
         }
       }
     };
   });
   const { withCacheBusting } = await import('./cacheInterceptor.js');
-  const wrappedHandle = withCacheBusting(handle);
+  const { wrapPreparedDatabase } = await import('./safeQuery.js');
+  const wrappedHandle = wrapPreparedDatabase(withCacheBusting(handle));
 
   const fs = await import('fs/promises');
   const rawSchema = await fs.readFile(schemaPath, 'utf-8').catch((error) => {
@@ -107,7 +123,7 @@ async function openDatabase(options = {}) {
     );
   });
 
-  return handle;
+  return wrappedHandle;
 }
 
 export async function initializeDatabase(options = {}) {

--- a/backend/src/database/safeQuery.js
+++ b/backend/src/database/safeQuery.js
@@ -1,0 +1,89 @@
+const SAFE_IDENTIFIER = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+const UNSAFE_SQL_PATTERNS = [
+  /(\bOR\b|\bAND\b)\s+['"]?\d+['"]?\s*=\s*['"]?\d+/i,
+  /;\s*DROP\b/i,
+  /UNION\s+SELECT/i,
+  /--/,
+  /\/\*/,
+];
+
+export function assertSafeIdentifier(value, label = 'identifier') {
+  if (typeof value !== 'string' || !SAFE_IDENTIFIER.test(value)) {
+    throw new Error(`Unsafe SQL ${label}: ${value}`);
+  }
+  return value;
+}
+
+export function resolveMappedSort(sortKey, mapping, fallbackKey = 'relevance') {
+  if (!mapping || typeof mapping !== 'object') {
+    throw new Error('Sort mapping is required');
+  }
+  const key = Object.prototype.hasOwnProperty.call(mapping, sortKey)
+    ? sortKey
+    : fallbackKey;
+  return mapping[key];
+}
+
+export function sanitizePositiveInteger(
+  value,
+  { min = 1, max = 365, fallback = 30 } = {}
+) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(min, parsed));
+}
+
+export function cutoffTimestampDaysAgo(days, now = Date.now()) {
+  const safeDays = sanitizePositiveInteger(days);
+  return new Date(now - safeDays * 86_400_000).toISOString();
+}
+
+export function validateParameterizedQuery(sql, params = []) {
+  if (typeof sql !== 'string' || !sql.trim()) {
+    throw new Error('SQL must be a non-empty string');
+  }
+  if (!Array.isArray(params)) {
+    throw new Error('SQL parameters must be an array');
+  }
+
+  for (const pattern of UNSAFE_SQL_PATTERNS) {
+    if (pattern.test(sql)) {
+      throw new Error('Potentially unsafe SQL pattern detected');
+    }
+  }
+
+  const placeholderCount = (sql.match(/\?/g) || []).length;
+  if (placeholderCount !== params.length) {
+    throw new Error(
+      `Parameter count mismatch: expected ${placeholderCount}, received ${params.length}`
+    );
+  }
+
+  return { sql, params };
+}
+
+export function wrapPreparedDatabase(db) {
+  if (!db || db.__preparedGuard) return db;
+
+  const guarded = Object.create(db);
+  guarded.__preparedGuard = true;
+
+  for (const method of ['all', 'get', 'run']) {
+    if (typeof db[method] !== 'function') continue;
+    guarded[method] = async function guardedQuery(sql, params = []) {
+      validateParameterizedQuery(sql, params);
+      return db[method](sql, params);
+    };
+  }
+
+  return guarded;
+}
+
+export default {
+  assertSafeIdentifier,
+  resolveMappedSort,
+  sanitizePositiveInteger,
+  cutoffTimestampDaysAgo,
+  validateParameterizedQuery,
+  wrapPreparedDatabase,
+};

--- a/backend/src/services/databaseService.js
+++ b/backend/src/services/databaseService.js
@@ -1,5 +1,6 @@
 import path from 'path';
 import fs from 'fs';
+import { validateParameterizedQuery } from '../database/safeQuery.js';
 
 /**
  * DatabaseService provides a lightweight wrapper around SQLite3 with async helpers.
@@ -25,7 +26,8 @@ class DatabaseService {
 
   async connect() {
     const { default: sqlite3 } = await import('sqlite3');
-    const { withCacheBusting } = await import('../database/cacheInterceptor.js');
+    const { withCacheBusting } =
+      await import('../database/cacheInterceptor.js');
     return new Promise((resolve, reject) => {
       const dbInstance = new sqlite3.Database(this.dbPath, (err) => {
         if (err) reject(err);
@@ -53,6 +55,7 @@ class DatabaseService {
 
   /** Run a SQL statement that does not return rows (e.g., INSERT, UPDATE). */
   async run(sql, params = []) {
+    validateParameterizedQuery(sql, params);
     return new Promise((resolve, reject) => {
       this.db.run(sql, params, function (err) {
         if (err) reject(err);
@@ -63,6 +66,7 @@ class DatabaseService {
 
   /** Retrieve a single row. */
   async get(sql, params = []) {
+    validateParameterizedQuery(sql, params);
     return new Promise((resolve, reject) => {
       this.db.get(sql, params, (err, row) => {
         if (err) reject(err);
@@ -73,6 +77,7 @@ class DatabaseService {
 
   /** Retrieve all matching rows. */
   async all(sql, params = []) {
+    validateParameterizedQuery(sql, params);
     return new Promise((resolve, reject) => {
       this.db.all(sql, params, (err, rows) => {
         if (err) reject(err);

--- a/backend/src/services/searchService.js
+++ b/backend/src/services/searchService.js
@@ -1,4 +1,8 @@
 import { getDatabase } from '../database/connection.js';
+import {
+  cutoffTimestampDaysAgo,
+  resolveMappedSort,
+} from '../database/safeQuery.js';
 
 class SearchService {
   constructor() {
@@ -149,7 +153,7 @@ class SearchService {
       }
 
       // Add sorting based on ranking algorithm
-      const sortMapping = {
+      const SORT_OPTIONS = {
         relevance:
           'search_rank DESC, field_weight DESC, p.completion_rate DESC',
         funding: 'p.current_funding DESC',
@@ -158,7 +162,7 @@ class SearchService {
         title: 'p.title ASC',
       };
 
-      searchQuery += ` ORDER BY ${sortMapping[sortBy] || sortMapping['relevance']}`;
+      searchQuery += ` ORDER BY ${resolveMappedSort(sortBy, SORT_OPTIONS)}`;
       searchQuery += ` LIMIT ? OFFSET ?`;
       queryParams.push(limit, offset);
 
@@ -423,17 +427,21 @@ class SearchService {
   // Get search analytics
   async getSearchAnalytics(days = 7) {
     try {
-      return await this.db.all(`
+      const cutoff = cutoffTimestampDaysAgo(days);
+      return await this.db.all(
+        `
         SELECT 
           DATE(timestamp) as date,
           COUNT(*) as search_count,
           AVG(response_time_ms) as avg_response_time,
           AVG(results_count) as avg_results
         FROM search_analytics
-        WHERE timestamp >= datetime('now', '-${days} days')
+        WHERE timestamp >= ?
         GROUP BY DATE(timestamp)
         ORDER BY date DESC
-      `);
+      `,
+        [cutoff]
+      );
     } catch (error) {
       console.error('Analytics error:', error);
       return [];

--- a/backend/src/services/stablecoinService.js
+++ b/backend/src/services/stablecoinService.js
@@ -1,5 +1,9 @@
 import { dbService } from './dbService.js';
 import cacheService from './cacheService.js';
+import {
+  cutoffTimestampDaysAgo,
+  sanitizePositiveInteger,
+} from '../database/safeQuery.js';
 
 const CACHE_PREFIX = 'stablecoin:';
 const CACHE_TTL = 60; // 1 minute
@@ -82,21 +86,26 @@ class StablecoinService {
   }
 
   async getPriceHistory(days = 30) {
-    const cacheKey = `${CACHE_PREFIX}price_history:${days}`;
+    const safeDays = sanitizePositiveInteger(days);
+    const cacheKey = `${CACHE_PREFIX}price_history:${safeDays}`;
     const cached = await cacheService.get(cacheKey);
     if (cached) return cached;
 
     const db = await dbService.getDb();
-    const history = await db.all(`
+    const cutoff = cutoffTimestampDaysAgo(safeDays);
+    const history = await db.all(
+      `
       SELECT price, target_price, timestamp
       FROM stablecoin_price_history
-      WHERE timestamp >= datetime('now', '-${days} days')
+      WHERE timestamp >= ?
       ORDER BY timestamp ASC
-    `);
+    `,
+      [cutoff]
+    );
 
     // If no data, generate simulated history
     if (history.length === 0) {
-      const simulated = this._generateSimulatedPriceHistory(days);
+      const simulated = this._generateSimulatedPriceHistory(safeDays);
       await cacheService.set(cacheKey, simulated, CACHE_TTL);
       return simulated;
     }

--- a/backend/src/services/syntheticAssetsService.js
+++ b/backend/src/services/syntheticAssetsService.js
@@ -12,6 +12,7 @@
 import { invokeContract } from './invokeService.js';
 import { redisService } from './redisService.js';
 import { databaseService } from './databaseService.js';
+import { assertSafeIdentifier } from '../database/safeQuery.js';
 import { logger } from '../utils/logger.js';
 
 const CACHE_TTL = {
@@ -607,7 +608,10 @@ class SyntheticAssetsService {
   }
 
   async updatePosition(positionId, updates) {
-    const fields = Object.keys(updates).map((key, i) => `${key} = $${i + 2}`);
+    const fields = Object.keys(updates).map((key, i) => {
+      assertSafeIdentifier(key, 'column');
+      return `${key} = $${i + 2}`;
+    });
     const values = Object.values(updates);
 
     await databaseService.query(

--- a/backend/tests/sqlInjection.test.js
+++ b/backend/tests/sqlInjection.test.js
@@ -1,0 +1,73 @@
+import {
+  assertSafeIdentifier,
+  cutoffTimestampDaysAgo,
+  resolveMappedSort,
+  sanitizePositiveInteger,
+  validateParameterizedQuery,
+} from '../src/database/safeQuery.js';
+
+describe('SQL injection guardrails', () => {
+  describe('assertSafeIdentifier', () => {
+    it('accepts safe column names', () => {
+      expect(assertSafeIdentifier('user_id')).toBe('user_id');
+    });
+
+    it('rejects injection payloads in identifiers', () => {
+      expect(() => assertSafeIdentifier('id; DROP TABLE users--')).toThrow(
+        /Unsafe SQL/
+      );
+      expect(() => assertSafeIdentifier('1=1')).toThrow(/Unsafe SQL/);
+    });
+  });
+
+  describe('resolveMappedSort', () => {
+    const mapping = {
+      relevance: 'rank DESC',
+      recent: 'created_at DESC',
+    };
+
+    it('uses allowlisted sort keys only', () => {
+      expect(resolveMappedSort('recent', mapping)).toBe('created_at DESC');
+      expect(resolveMappedSort('recent; DROP TABLE projects--', mapping)).toBe(
+        'rank DESC'
+      );
+    });
+  });
+
+  describe('sanitizePositiveInteger', () => {
+    it('neutralizes OR 1=1 style day inputs', () => {
+      expect(sanitizePositiveInteger('OR 1=1')).toBe(30);
+      expect(sanitizePositiveInteger('7 OR 1=1')).toBe(7);
+      expect(sanitizePositiveInteger('-10')).toBe(1);
+      expect(sanitizePositiveInteger('3650')).toBe(365);
+    });
+  });
+
+  describe('cutoffTimestampDaysAgo', () => {
+    it('returns ISO timestamps for bounded day windows', () => {
+      const now = Date.parse('2026-01-31T00:00:00.000Z');
+      const cutoff = cutoffTimestampDaysAgo('10', now);
+      expect(cutoff).toBe('2026-01-21T00:00:00.000Z');
+    });
+  });
+
+  describe('validateParameterizedQuery', () => {
+    it('accepts prepared statements with matching placeholders', () => {
+      expect(() =>
+        validateParameterizedQuery('SELECT * FROM users WHERE id = ?', [1])
+      ).not.toThrow();
+    });
+
+    it('rejects classic SQL injection strings in raw SQL', () => {
+      expect(() =>
+        validateParameterizedQuery('SELECT * FROM users WHERE id = 1 OR 1=1')
+      ).toThrow(/unsafe SQL/i);
+      expect(() =>
+        validateParameterizedQuery('SELECT * FROM users; DROP TABLE users')
+      ).toThrow(/unsafe SQL/i);
+      expect(() =>
+        validateParameterizedQuery('SELECT * FROM users WHERE id = ?', [])
+      ).toThrow(/Parameter count mismatch/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add safeQuery guardrails for identifiers, sort maps, and parameterized validation
- Convert dynamic SQL in search/stablecoin services to bound parameters
- Wrap database accessors with prepared-statement enforcement and ESLint rule
- Add SQL injection neutralization tests

Closes #732

## Test plan
- [x] sqlInjection.test.js passes
- [ ] CI lint/format checks

Made with [Cursor](https://cursor.com)