### PR TITLE
Optimize Monaco editor load path

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -6,8 +6,16 @@ const config = {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
   transform: {
-    '^.+\\.(ts|tsx)$': 'babel-jest',
-    '^.+\\.js$': 'babel-jest',
+    '^.+\\.(ts|tsx)$': ['babel-jest', {
+      presets: [
+        ['@babel/preset-react', { runtime: 'automatic' }],
+        '@babel/preset-typescript',
+      ],
+      plugins: ['@babel/plugin-transform-modules-commonjs'],
+    }],
+    '^.+\\.js$': ['babel-jest', {
+      plugins: ['@babel/plugin-transform-modules-commonjs'],
+    }],
   },
   transformIgnorePatterns: [
     '/node_modules/(?!(lucide-react)/)',

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom';
+require('@testing-library/jest-dom');

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -26,6 +26,22 @@ const nextConfig: NextConfig = {
         ...config.resolve.fallback,
         fs: false,
       };
+      config.optimization = {
+        ...config.optimization,
+        splitChunks: {
+          ...config.optimization?.splitChunks,
+          cacheGroups: {
+            ...config.optimization?.splitChunks?.cacheGroups,
+            monacoEditor: {
+              test: /[\\/]node_modules[\\/](@monaco-editor|monaco-editor)[\\/]/,
+              name: "monaco-editor",
+              chunks: "all",
+              priority: 30,
+              enforce: true,
+            },
+          },
+        },
+      };
     }
 
     return config;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev",
     "build": "next build --webpack",
     "start": "next start",
+    "test": "node ../node_modules/jest/bin/jest.js --runInBand",
     "lint": "eslint"
   },
   "dependencies": {
@@ -23,6 +24,7 @@
     "graphql": "^16.13.2",
     "graphql-tag": "^2.12.6",
     "lucide-react": "^1.17.0",
+    "monaco-editor": "^0.55.1",
     "monaco-languageclient": "^10.7.0",
     "next": "16.2.6",
     "optimism": "^0.18.1",

--- a/frontend/src/__tests__/lib/editorLoadScheduler.test.ts
+++ b/frontend/src/__tests__/lib/editorLoadScheduler.test.ts
@@ -1,0 +1,54 @@
+import {
+  loadMonacoEditor,
+  resetMonacoEditorLoaderForTests,
+  scheduleEditorLoad,
+} from "../../lib/editorLoadScheduler";
+
+describe("editorLoadScheduler", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+    resetMonacoEditorLoaderForTests();
+  });
+
+  it("schedules editor loading with requestIdleCallback when available", () => {
+    const task = jest.fn();
+    const requestIdleCallback = jest.fn((callback: IdleRequestCallback) => {
+      callback({ didTimeout: false, timeRemaining: () => 10 });
+      return 42;
+    });
+    const cancelIdleCallback = jest.fn();
+
+    scheduleEditorLoad(task, {
+      requestIdleCallback,
+      cancelIdleCallback,
+    } as unknown as Window & typeof globalThis);
+
+    expect(requestIdleCallback).toHaveBeenCalledWith(expect.any(Function), {
+      timeout: 1500,
+    });
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to a macrotask when requestIdleCallback is unavailable", () => {
+    jest.useFakeTimers();
+    const task = jest.fn();
+
+    scheduleEditorLoad(task, window);
+
+    expect(task).not.toHaveBeenCalled();
+    jest.runOnlyPendingTimers();
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches the Monaco editor import so repeat mounts share one download", async () => {
+    const importer = jest.fn(async () => ({ default: jest.fn() as never }));
+
+    const firstLoad = loadMonacoEditor(importer);
+    const secondLoad = loadMonacoEditor(importer);
+
+    expect(firstLoad).toBe(secondLoad);
+    await expect(firstLoad).resolves.toEqual({ default: expect.any(Function) });
+    expect(importer).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/frontend/src/app/PlaygroundClient.tsx
+++ b/frontend/src/app/PlaygroundClient.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import dynamic from "next/dynamic";
 import MobileEditor from "@/components/MobileEditor";
+import { preloadMonacoEditor } from "@/lib/editorLoadScheduler";
 
 const Editor = dynamic(() => import("@/components/Editor"), {
   ssr: false,
@@ -253,6 +254,10 @@ function createMockInvocationPayload(
 }
 
 export default function Home() {
+  useEffect(() => {
+    return preloadMonacoEditor();
+  }, []);
+
   const [code, setCode] = useState(DEFAULT_CODE);
   const [logs, setLogs] = useState<string[]>([
     `Soroban Playground ready.`,

--- a/frontend/src/components/Editor.tsx
+++ b/frontend/src/components/Editor.tsx
@@ -1,48 +1,78 @@
 "use client";
 
-import React from "react";
-import MonacoEditor from "@monaco-editor/react";
+import React, { useEffect, useState } from "react";
+import type MonacoEditorComponent from "@monaco-editor/react";
+import { scheduleEditorLoad, loadMonacoEditor } from "@/lib/editorLoadScheduler";
+import { configureMonacoWorkers } from "@/lib/monacoWorkers";
 
 interface EditorProps {
   code: string;
   setCode: (value: string) => void;
 }
 
+function EditorLoadingState() {
+  return (
+    <div className="flex items-center justify-center h-full w-full text-gray-500">
+      <div className="flex flex-col items-center gap-3">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-teal-500" />
+        <span className="text-xs font-mono text-gray-400">Loading editor...</span>
+      </div>
+    </div>
+  );
+}
+
 export default function Editor({ code, setCode }: EditorProps) {
+  const [MonacoEditor, setMonacoEditor] = useState<typeof MonacoEditorComponent | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const cancelLoad = scheduleEditorLoad(async () => {
+      configureMonacoWorkers();
+      const editorModule = await loadMonacoEditor();
+
+      if (mounted) {
+        setMonacoEditor(() => editorModule.default);
+      }
+    });
+
+    return () => {
+      mounted = false;
+      cancelLoad();
+    };
+  }, []);
+
   return (
     <div className="relative h-[500px] w-full rounded-xl overflow-hidden border border-gray-800 bg-[#1e1e1e] shadow-2xl">
-      <MonacoEditor
-        height="100%"
-        width="100%"
-        language="rust"
-        theme="vs-dark"
-        value={code}
-        onChange={(val) => setCode(val || "")}
-        options={{
-          minimap: { enabled: false },
-          fontSize: 14,
-          padding: { top: 16, bottom: 16 },
-          scrollBeyondLastLine: false,
-          smoothScrolling: true,
-          cursorBlinking: "smooth",
-          cursorSmoothCaretAnimation: "on",
-          formatOnPaste: true,
-          wordWrap: "on",
-          lineNumbers: "on",
-          bracketPairColorization: { enabled: true },
-          tabSize: 4,
-          insertSpaces: true,
-          renderLineHighlight: "all",
-        }}
-        loading={
-          <div className="flex items-center justify-center h-full w-full text-gray-500">
-            <div className="flex flex-col items-center gap-3">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-teal-500" />
-              <span className="text-xs font-mono text-gray-400">Loading editor...</span>
-            </div>
-          </div>
-        }
-      />
+      {MonacoEditor ? (
+        <MonacoEditor
+          height="100%"
+          width="100%"
+          language="rust"
+          theme="vs-dark"
+          value={code}
+          onChange={(val) => setCode(val || "")}
+          options={{
+            minimap: { enabled: false },
+            fontSize: 14,
+            padding: { top: 16, bottom: 16 },
+            scrollBeyondLastLine: false,
+            smoothScrolling: true,
+            cursorBlinking: "smooth",
+            cursorSmoothCaretAnimation: "on",
+            formatOnPaste: true,
+            wordWrap: "on",
+            lineNumbers: "on",
+            bracketPairColorization: { enabled: true },
+            tabSize: 4,
+            insertSpaces: true,
+            renderLineHighlight: "all",
+          }}
+          loading={<EditorLoadingState />}
+        />
+      ) : (
+        <EditorLoadingState />
+      )}
     </div>
   );
 }

--- a/frontend/src/lib/editorLoadScheduler.ts
+++ b/frontend/src/lib/editorLoadScheduler.ts
@@ -1,0 +1,70 @@
+"use client";
+
+import type MonacoEditorComponent from "@monaco-editor/react";
+
+type MonacoEditorModule = {
+  default: typeof MonacoEditorComponent;
+};
+
+type IdleWindow = Window & {
+  requestIdleCallback?: (
+    callback: IdleRequestCallback,
+    options?: IdleRequestOptions
+  ) => number;
+  cancelIdleCallback?: (handle: number) => void;
+};
+
+let monacoEditorPromise: Promise<MonacoEditorModule> | null = null;
+
+export function scheduleEditorLoad(
+  task: () => void | Promise<void>,
+  targetWindow: IdleWindow | undefined = typeof window === "undefined"
+    ? undefined
+    : (window as IdleWindow)
+): () => void {
+  if (!targetWindow) {
+    void task();
+    return () => {};
+  }
+
+  if (typeof targetWindow.requestIdleCallback === "function") {
+    const handle = targetWindow.requestIdleCallback(
+      () => {
+        void task();
+      },
+      { timeout: 1500 }
+    );
+
+    return () => {
+      targetWindow.cancelIdleCallback?.(handle);
+    };
+  }
+
+  const handle = targetWindow.setTimeout(() => {
+    void task();
+  }, 0);
+
+  return () => {
+    targetWindow.clearTimeout(handle);
+  };
+}
+
+export function loadMonacoEditor(
+  importer: () => Promise<MonacoEditorModule> = () => import("@monaco-editor/react")
+): Promise<MonacoEditorModule> {
+  if (!monacoEditorPromise) {
+    monacoEditorPromise = importer();
+  }
+
+  return monacoEditorPromise;
+}
+
+export function preloadMonacoEditor(): () => void {
+  return scheduleEditorLoad(async () => {
+    await loadMonacoEditor();
+  });
+}
+
+export function resetMonacoEditorLoaderForTests() {
+  monacoEditorPromise = null;
+}

--- a/frontend/src/lib/monacoWorkers.ts
+++ b/frontend/src/lib/monacoWorkers.ts
@@ -1,0 +1,57 @@
+"use client";
+
+type MonacoWorkerEnvironment = {
+  getWorker: (_moduleId: string, label: string) => Worker;
+  __sorobanPlaygroundConfigured?: boolean;
+};
+
+function createWorker(label: string): Worker {
+  switch (label) {
+    case "json":
+      return new Worker(
+        new URL("monaco-editor/esm/vs/language/json/json.worker.js", import.meta.url),
+        { type: "module", name: "monaco-json-worker" }
+      );
+    case "css":
+    case "scss":
+    case "less":
+      return new Worker(
+        new URL("monaco-editor/esm/vs/language/css/css.worker.js", import.meta.url),
+        { type: "module", name: "monaco-css-worker" }
+      );
+    case "html":
+    case "handlebars":
+    case "razor":
+      return new Worker(
+        new URL("monaco-editor/esm/vs/language/html/html.worker.js", import.meta.url),
+        { type: "module", name: "monaco-html-worker" }
+      );
+    case "typescript":
+    case "javascript":
+      return new Worker(
+        new URL("monaco-editor/esm/vs/language/typescript/ts.worker.js", import.meta.url),
+        { type: "module", name: "monaco-ts-worker" }
+      );
+    default:
+      return new Worker(
+        new URL("monaco-editor/esm/vs/editor/editor.worker.js", import.meta.url),
+        { type: "module", name: "monaco-editor-worker" }
+      );
+  }
+}
+
+export function configureMonacoWorkers() {
+  if (typeof window === "undefined") return;
+
+  const globalTarget = globalThis as typeof globalThis & {
+    MonacoEnvironment?: MonacoWorkerEnvironment;
+  };
+
+  if (globalTarget.MonacoEnvironment?.__sorobanPlaygroundConfigured) return;
+
+  globalTarget.MonacoEnvironment = {
+    __sorobanPlaygroundConfigured: true,
+    getWorker: (_moduleId: string, label: string) => createWorker(label),
+  };
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1710,6 +1710,7 @@
         "graphql": "^16.13.2",
         "graphql-tag": "^2.12.6",
         "lucide-react": "^1.17.0",
+        "monaco-editor": "^0.55.1",
         "monaco-languageclient": "^10.7.0",
         "next": "16.2.6",
         "optimism": "^0.18.1",
@@ -15960,6 +15961,25 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "license": "MIT"
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/monaco-editor/node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/monaco-languageclient": {
       "version": "10.7.0",


### PR DESCRIPTION
Summary
- Defers Monaco editor loading so the playground shell can render without pulling Monaco into the initial editor component execution path.
- Adds an idle-time editor loader with import caching so repeated editor mounts share the same Monaco download.
- Configures Monaco worker routing and adds a dedicated Webpack cache group for Monaco editor chunks.
- Adds the missing monaco-editor peer dependency used by @monaco-editor/react.

Issue
- Closes #777

Changes
- Replaced eager @monaco-editor/react import in Editor with an idle-scheduled dynamic loader.
- Added Monaco worker environment setup for editor/language workers.
- Preloads Monaco after the playground client mounts using requestIdleCallback when available.
- Adds a focused test for idle scheduling and import caching.
- Keeps Jest transform local to Jest config so app builds are not forced onto Babel.

Validation
- Passed: npm.cmd run test --workspace frontend -- --testPathPattern=editorLoadScheduler
- Build: attempted, but local Next build is blocked by the environment's native SWC issue on Windows/Node: @next/swc-win32-x64-msvc is not a valid Win32 application, then Next build worker exits with invalid type: unit value, expected usize.

Notes
- No unrelated app behavior changed; the editor still renders the same loading UI and Monaco options once loaded.