### PR TITLE
feat(backend): implement graceful shutdown handler (Issue #706)

### DIFF
--- a/backend/src/cleanupWorker.js
+++ b/backend/src/cleanupWorker.js
@@ -10,6 +10,7 @@ const OLD_THRESHOLD_MS = 60 * 60 * 1000; // 1 hour
 const TEMP_DIR_PREFIX = '.tmp_compile_';
 const MAX_RETRY_ATTEMPTS = 3;
 const RETRY_DELAY_MS = 1000;
+let intervalId = null;
 
 /**
  * Scans a directory for temporary compilation folders
@@ -104,10 +105,16 @@ async function cleanupTempDirectories() {
   console.log('Temporary directory cleanup finished.');
 }
 
+export function stopCleanupWorker() {
+  if (intervalId) {
+    clearInterval(intervalId);
+    intervalId = null;
+  }
+}
+
 /**
  * Starts the background worker for cleaning up temporary directories.
  * It runs immediately upon call and then at regular intervals.
- * Includes graceful shutdown handling.
  */
 export function startCleanupWorker() {
   console.log(
@@ -118,18 +125,7 @@ export function startCleanupWorker() {
   cleanupTempDirectories().catch(console.error);
 
   // Then run at intervals
-  const intervalId = setInterval(() => {
+  intervalId = setInterval(() => {
     cleanupTempDirectories().catch(console.error);
   }, CLEANUP_INTERVAL_MS);
-
-  // Set up graceful shutdown
-  process.on('SIGTERM', () => {
-    console.log('Shutting down cleanup worker gracefully...');
-    clearInterval(intervalId);
-  });
-
-  process.on('SIGINT', () => {
-    console.log('Shutting down cleanup worker gracefully...');
-    clearInterval(intervalId);
-  });
 }

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -16,9 +16,9 @@ import { corsOptions } from './config/cors.js';
 import { applyServerTuning } from './config/http2Config.js';
 import { http2PushMiddleware } from './middleware/http2Push.js';
 import apiRouter from './routes/api.js';
-import { startCleanupWorker } from './cleanupWorker.js';
+import { startCleanupWorker, stopCleanupWorker } from './cleanupWorker.js';
 import { notFoundHandler, errorHandler } from './middleware/errorHandler.js';
-import { setupWebsocketServer } from './websocket.js';
+import { setupWebsocketServer, closeWebsocketServer } from './websocket.js';
 import { initializeCompileService } from './services/compileService.js';
 import adminRoute from './routes/admin.js';
 import metricsRoute, { requestLatency } from './routes/metrics.js';
@@ -39,6 +39,7 @@ import { setupGraphQL } from './graphql/index.js';
 import {
   initializeDatabase,
   refreshDatabaseConnection,
+  closeDatabase,
 } from './database/connection.js';
 import { compressionMiddleware } from './middleware/compressionMiddleware.js';
 import feeEngineRoute from './routes/feeEngine.js';
@@ -47,13 +48,19 @@ import featureFlagService from './services/featureFlagService.js';
 import { LedgerSyncService } from './services/ledgerSyncService.js';
 import snippetsRoute from './routes/snippets.js';
 import deployQueueRoute from './routes/deployQueue.js';
+import { startWebhookDispatcher, stopWebhookDispatcher } from './services/webhookDispatcher.js';
+import { webhooksRoute } from './routes/webhooks.js';
+import corsAdminRoute from './routes/corsAdmin.js';
+import serviceRegistryRoute from './routes/serviceRegistry.js';
+import batchSubmitterRoute from './routes/batchSubmitter.js';
+import { setupSwagger } from './docs/swagger.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const app = express();
-const server = http.createServer(app);
-applyServerTuning(server); // HTTP/2: keep-alive + headers-timeout tuning
+let httpServer = http.createServer(app);
+applyServerTuning(httpServer); // HTTP/2: keep-alive + headers-timeout tuning
 
 // TLS/SSL Hardening configuration
 const httpsOptions = {
@@ -98,7 +105,7 @@ try {
 // Fallback to HTTP if no certs are provided, otherwise use HTTPS
 const server = hasCertificates
   ? https.createServer(httpsOptions, app)
-  : http.createServer(app);
+  : httpServer;
 const PORT = process.env.PORT || 5000;
 
 // Load package.json for version info
@@ -308,6 +315,8 @@ function setupCredentialRotation() {
   credentialRotationService.start();
 }
 
+let ledgerSyncServiceInstance = null;
+
 // WebSocket + compile service + database init
 initializeDatabase()
   .then((db) => {
@@ -319,7 +328,8 @@ initializeDatabase()
     startWebhookDispatcher();
     setupCredentialRotation();
     if (process.env.LEDGER_SYNC_ENABLED === 'true') {
-      new LedgerSyncService({ db }).start();
+      ledgerSyncServiceInstance = new LedgerSyncService({ db });
+      ledgerSyncServiceInstance.start();
     }
 
     // Start listening
@@ -336,9 +346,54 @@ initializeDatabase()
   });
 
 // Graceful shutdown
-process.on('SIGTERM', () => {
-  console.log('Shutting down gracefully...');
-  server.close(() => process.exit(0));
-});
+let isShuttingDown = false;
+const SHUTDOWN_TIMEOUT_MS = 30000;
+
+async function gracefulShutdown(signal) {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+  console.log(`\n[Shutdown] Received ${signal}. Starting graceful shutdown...`);
+
+  const forceExit = setTimeout(() => {
+    console.error('[Shutdown] Graceful shutdown timed out after 30s. Force exiting.');
+    process.exit(1);
+  }, SHUTDOWN_TIMEOUT_MS);
+
+  try {
+    // 1. Stop background workers
+    console.log('[Shutdown] Stopping background workers...');
+    stopCleanupWorker();
+    stopWebhookDispatcher();
+    if (ledgerSyncServiceInstance) ledgerSyncServiceInstance.stop();
+    await oracleWorkerPool.stop();
+    credentialRotationService.stop();
+
+    // 2. Stop accepting new HTTP requests
+    console.log('[Shutdown] Stopping HTTP server...');
+    await new Promise((resolve) => server.close(resolve));
+
+    // 3. Stop WebSocket connections
+    console.log('[Shutdown] Closing WebSocket server...');
+    closeWebsocketServer();
+
+    // 4. Close database and Redis connections
+    console.log('[Shutdown] Closing database and Redis connections...');
+    await closeDatabase();
+    if (redisService.client) {
+      await redisService.client.quit();
+    }
+
+    console.log('[Shutdown] Graceful shutdown completed cleanly.');
+    clearTimeout(forceExit);
+    process.exit(0);
+  } catch (err) {
+    console.error('[Shutdown] Error during shutdown:', err);
+    clearTimeout(forceExit);
+    process.exit(1);
+  }
+}
+
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));
 
 export default app;

--- a/backend/src/websocket.js
+++ b/backend/src/websocket.js
@@ -39,11 +39,15 @@ export function broadcastTreasuryEvent(event) {
   }
 }
 
+let wssInstance = null;
+
 export function setupWebsocketServer(httpServer) {
   const wss = new WebSocketServer({
     server: httpServer,
     path: '/ws',
   });
+
+  wssInstance = wss;
 
   wss.on('error', (err) => {
     console.error('WebSocketServer error:', err.message);
@@ -177,6 +181,16 @@ export function setupWebsocketServer(httpServer) {
   }, 2000);
 
   return wss;
+}
+
+export function closeWebsocketServer() {
+  if (wssInstance) {
+    for (const socket of clients) {
+      socket.terminate();
+    }
+    clients.clear();
+    wssInstance.close();
+  }
 }
 
 export function broadcast(payload) {


### PR DESCRIPTION
## What does this PR do?

This PR implements a centralized graceful shutdown process for the backend server. It intercepts termination signals (`SIGTERM`, `SIGINT`) to cleanly finish processing active requests and tear down background resources. Specifically, it:
- Stops background workers from picking up new jobs (cleanup worker, webhook dispatcher, oracle worker pool, and ledger sync service).
- Stops the Express server and WebSocket server from accepting new connections.
- Sets a 30-second timeout window. If connections don't drain by then, the process forcefully exits to prevent hanging.
- Cleanly closes the database and Redis connections after the HTTP server and workers drain.
- Fixes a syntax bug where the `server` variable was being re-declared improperly.

## Related Issue
Closes #706

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor / Code improvement
- [ ] Other (please describe):

## 🗂️ Affected Area(s)
- [ ] frontend/ — Next.js UI / Monaco editor
- [x] backend/ — Express API routes (/compile, /deploy, /invoke)
- [ ] contracts/ — Example Soroban contracts
- [ ] .github/ — Templates, workflows, CI
- [ ] Documentation / README
- [ ] Other: <!-- describe -->

## How Has This Been Tested?

The implementation was tested by sending termination signals locally and ensuring the backend shuts down in the correct sequential order without leaking connections.

- [ ] Tested in the browser (local dev server)
- [ ] Verified changes work across different missions
- [ ] Checked Monaco Editor behavior (if applicable)
- [x] Ran all existing tests (`npm test`)
- [x] No new console errors or warnings

## Screenshots / Demo (if applicable)

N/A (Backend logic changes)

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated the documentation (if needed)
- [x] My changes do not introduce new warnings or errors
- [x] New and existing tests pass locally