### PR TITLE
feat(backend): implement automated WASM temp directory garbage collector service 

### DIFF
--- a/backend/src/services/temp-cleanup.service.spec.ts
+++ b/backend/src/services/temp-cleanup.service.spec.ts
@@ -1,0 +1,45 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import * as fs from 'fs/promises';
+import { TempCleanupService } from './temp-cleanup.service';
+
+jest.mock('fs/promises');
+
+describe('TempCleanupService', () => {
+  let service: TempCleanupService;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [TempCleanupService],
+    }).compile();
+
+    service = module.get<TempCleanupService>(TempCleanupService);
+  });
+
+  it('should identify and remove temp compile directories older than 30 minutes', async () => {
+    const thirtyFiveMinutesAgo = Date.now() - 35 * 60 * 1000;
+
+    (fs.readdir as jest.Mock)
+      .mockResolvedValueOnce([
+        { isDirectory: () => true, name: '.tmp_compile_active123' },
+        { isDirectory: () => true, name: '.tmp_compile_stale456' },
+        { isDirectory: () => true, name: 'other_dir' },
+      ])
+      .mockResolvedValue([]); // Empty sub-folder recursive reads
+
+    (fs.stat as jest.Mock).mockResolvedValue({
+      mtimeMs: thirtyFiveMinutesAgo,
+      size: 1024 * 1024,
+      isFile: () => true,
+      isDirectory: () => false,
+    });
+
+    (fs.rm as jest.Mock).mockResolvedValue(undefined);
+
+    const result = await service.cleanupWasmTempDirectories();
+
+    expect(fs.rm).toHaveBeenCalledTimes(2);
+    expect(result.deletedDirs).toBe(2);
+  });
+});

--- a/backend/src/services/temp-cleanup.service.ts
+++ b/backend/src/services/temp-cleanup.service.ts
@@ -1,0 +1,90 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+@Injectable()
+export class TempCleanupService {
+  private readonly logger = new Logger(TempCleanupService.name);
+  private readonly tempBaseDir = process.env.TMP_BUILD_DIR || '/tmp';
+  private readonly maxAgeMs = 30 * 60 * 1000; // 30 minutes threshold
+
+  /**
+   * Hourly Cron Job: Purges leftover `.tmp_compile_*` directories older than 30 minutes.
+   */
+  @Cron(CronExpression.EVERY_HOUR)
+  async cleanupWasmTempDirectories(): Promise<{ deletedDirs: number; reclaimedBytes: number }> {
+    this.logger.log('Starting WASM build temp directory garbage collection...');
+
+    let deletedDirs = 0;
+    let reclaimedBytes = 0;
+
+    try {
+      const entries = await fs.readdir(this.tempBaseDir, { withFileTypes: true });
+      const now = Date.now();
+
+      for (const entry of entries) {
+        // Target directories matching the compilation pattern '.tmp_compile_*'
+        if (entry.isDirectory() && entry.name.startsWith('.tmp_compile_')) {
+          const dirPath = path.join(this.tempBaseDir, entry.name);
+
+          try {
+            const stats = await fs.stat(dirPath);
+            const dirAgeMs = now - stats.mtimeMs;
+
+            if (dirAgeMs > this.maxAgeMs) {
+              const dirSizeBytes = await this.calculateDirectorySize(dirPath);
+              
+              // Safely delete stale temp build folder recursively
+              await fs.rm(dirPath, { recursive: true, force: true });
+
+              deletedDirs++;
+              reclaimedBytes += dirSizeBytes;
+
+              this.logger.debug(
+                `Purged temp directory: ${entry.name} (Age: ${Math.round(dirAgeMs / 60000)}m, Size: ${(
+                  dirSizeBytes /
+                  (1024 * 1024)
+                ).toFixed(2)} MB)`,
+              );
+            }
+          } catch (statOrRmError) {
+            this.logger.error(`Failed to process or delete temp dir ${dirPath}:`, statOrRmError);
+          }
+        }
+      }
+
+      const reclaimedMb = (reclaimedBytes / (1024 * 1024)).toFixed(2);
+      this.logger.log(
+        `WASM Garbage Collection finished. Reclaimed ${reclaimedMb} MB across ${deletedDirs} temp directories.`,
+      );
+
+      return { deletedDirs, reclaimedBytes };
+    } catch (error) {
+      this.logger.error('Error scanning base temp directory for WASM cleanup:', error);
+      return { deletedDirs: 0, reclaimedBytes: 0 };
+    }
+  }
+
+  /**
+   * Helper to recursively sum file sizes within a directory before deletion.
+   */
+  private async calculateDirectorySize(dirPath: string): Promise<number> {
+    let totalSize = 0;
+    try {
+      const entries = await fs.readdir(dirPath, { withFileTypes: true });
+      for (const entry of entries) {
+        const fullPath = path.join(dirPath, entry.name);
+        if (entry.isDirectory()) {
+          totalSize += await this.calculateDirectorySize(fullPath);
+        } else if (entry.isFile()) {
+          const stats = await fs.stat(fullPath);
+          totalSize += stats.size;
+        }
+      }
+    } catch {
+      // Return accumulated size if sub-path fails during calculation
+    }
+    return totalSize;
+  }
+}


### PR DESCRIPTION
# 🎯 Overview & High-Level Motivation
Resolves #1030 

Failed or aborted Rust/Soroban WASM contract builds leave behind temporary artifacts inside `.tmp_compile_*` directories. Over time, these orphaned build directories accumulate and consume available disk storage on worker nodes.

This PR introduces an automated background cleanup worker (`TempCleanupService`) running on an hourly schedule:
* Target directories matching `.tmp_compile_*`.
* Evaluates directory modified timestamps (`mtimeMs`).
* Purges directories older than **30 minutes**.
* Computes and logs reclaimed disk space and file metrics.

---

## 🛠️ Key Architectural Changes

### 1. Garbage Collection Service (`src/common/services/temp-cleanup.service.ts`)
* `@Cron(CronExpression.EVERY_HOUR)` decorator schedule.
* Asynchronous `fs/promises` scanning and recursive folder deletion using `fs.rm(path, { recursive: true, force: true })`.
* Safe error handling preventing scan failures from crashing the background daemon worker process.

---

## 🧪 Testing & Verification

### Unit Testing
```bash
npm run test src/common/services/temp-cleanup.service.spec.ts