### PR TITLE
docs: add upgradeable contract pattern with timelock specification (#1033)

### DIFF
--- a/docs/upgradeable_timelock_pattern.md
+++ b/docs/upgradeable_timelock_pattern.md
@@ -1,0 +1,32 @@
+# Upgradeable Contract Pattern with Admin Timelock & Emergency Pause
+
+Design pattern specification for upgradeable Soroban contracts with a mandatory 48-hour admin timelock and circuit-breaker emergency pause capabilities.
+
+---
+
+## 1. Timelock Upgrade Architecture
+
+```
+[ Admin Proposes Upgrade ] ───> [ Storage: Pending Hash + Unlock Timestamp ]
+                                                │
+                                                ▼ (Must Wait 48 Hours)
+[ Admin Executes Upgrade ] <─── [ Require Current Timestamp >= Unlock Timestamp ]
+```
+
+- **Timelock Delay:** 172,800 seconds (48 hours).
+- **Event Emission:** `upgrade_proposed(hash, unlock_time)` emitted when queued.
+
+---
+
+## 2. Emergency Pause Mechanism
+
+- **Entrypoint:** `set_paused(env, paused: bool)`
+- **Auth:** Requires Admin signature.
+- **Guard:** All mutative user calls check `require_not_paused(&env)` before execution.
+
+---
+
+## References
+
+- Implementation: [`contracts/upgradeable_pattern/src/lib.rs`](../contracts/upgradeable_pattern/src/lib.rs)
+- Issue reference: Fixes #1033


### PR DESCRIPTION
Add Upgradeable Contract Pattern with Timelock Specification (#1033)

Added docs/upgradeable_timelock_pattern.md with:
- 48-hour admin timelock architecture and emergency pause circuit breaker

Payout Wallet (EVM): 0x20d3ea74f5534c760fb94753cfa3f4b7fce4d17f

Fixes #1033