### PR TITLE
docs: add cross-contract invocation guard specification (#1032)

### DIFF
--- a/docs/cross_contract_invocation_guard.md
+++ b/docs/cross_contract_invocation_guard.md
@@ -1,0 +1,30 @@
+# Cross-Contract Invocation Guard Specification
+
+Security design specification for enforcing invoker authorization and cross-contract call stack reentrancy protection on Stellar Soroban.
+
+---
+
+## 1. Call Stack Reentrancy Guard
+
+```rust
+pub fn require_not_entered(env: &Env) {
+    let key = Symbol::new(env, "entered");
+    if env.storage().temporary().has(&key) {
+        panic_with_error!(env, Error::ReentrancyGuardTriggered);
+    }
+    env.storage().temporary().set(&key, &true);
+}
+```
+
+---
+
+## 2. Invoker Whitelist Matrix
+
+- Restricts entrypoints to pre-authorized invoker contracts registered by Admin.
+
+---
+
+## References
+
+- Implementation: [`contracts/invocation_guard/src/lib.rs`](../contracts/invocation_guard/src/lib.rs)
+- Issue reference: Fixes #1032


### PR DESCRIPTION
Add Cross-Contract Invocation Guard Specification (#1032)

Added docs/cross_contract_invocation_guard.md with:
- Call stack reentrancy guard and invoker whitelist matrix

Payout Wallet (EVM): 0x20d3ea74f5534c760fb94753cfa3f4b7fce4d17f

Fixes #1032