### PR TITLE
feat(payment-splitter): implement robust error handling and value conservation

### DIFF
--- a/contracts/payment_splitter/Cargo.toml
+++ b/contracts/payment_splitter/Cargo.toml
@@ -2,6 +2,23 @@
 name = "payment_splitter"
 version = "0.1.0"
 edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-soroban-sdk = "0.10.0"
+soroban-sdk = "20.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "20.0.0", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/payment_splitter/src/lib.rs
+++ b/contracts/payment_splitter/src/lib.rs
@@ -1,39 +1,174 @@
-//! Dummy Payment Splitter contract with robust error handling
-use soroban_sdk::{contractimpl, Env, Symbol, Vec, Bytes, Error};
+#![no_std]
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum SplitterError {
-    /// Returned when the input amount is zero
-    ZeroAmount,
-    /// Returned when recipient address is invalid
-    InvalidRecipient,
-    /// Generic contract error wrapper
-    ContractError(Error),
+//! Payment Splitter — splits a payment equally among a set of recipients.
+//!
+//! ## Error handling (issue #999)
+//!
+//! The previous version declared a `SplitterError` enum that could never leave
+//! the contract: it was a plain Rust enum rather than `#[contracterror]`, so it
+//! had no `u32` discriminant to encode into a failed invocation's result. A
+//! caller could not distinguish "amount was zero" from "recipient list was
+//! empty" — or from the contract panicking outright.
+//!
+//! Every failure mode is now a numbered `Error` variant, matching the
+//! convention used across the other contracts in this repo, so off-chain
+//! tooling can decode a failure into a specific cause.
+//!
+//! ## Conservation of value
+//!
+//! `amount` rarely divides evenly by the recipient count. The previous
+//! implementation computed the remainder, wrote a comment saying it would
+//! "still proceed", and dropped it — silently losing up to `n - 1` stroops on
+//! every call. Splitting money must not lose money, so the remainder is now
+//! distributed deterministically: the first `remainder` recipients each receive
+//! one extra unit. The sum of all shares is always exactly `amount`, which
+//! `split_shares` asserts.
+
+use soroban_sdk::{
+    contract, contracterror, contractimpl, token, Address, Env, Vec,
+};
+
+/// Upper bound on recipients per call.
+///
+/// Each recipient costs a token transfer, and a list long enough to exhaust the
+/// ledger's CPU budget would fail *after* transferring to some of them —
+/// leaving a partial split with no record of where it stopped. Rejecting the
+/// call up front keeps the operation all-or-nothing.
+pub const MAX_RECIPIENTS: u32 = 100;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    /// `amount` was zero or negative.
+    ZeroAmount = 1,
+    /// The recipient list was empty.
+    NoRecipients = 2,
+    /// The recipient list exceeded `MAX_RECIPIENTS`.
+    TooManyRecipients = 3,
+    /// The same address appeared more than once in the recipient list.
+    DuplicateRecipient = 4,
+    /// `amount` is smaller than the recipient count, so at least one recipient
+    /// would receive nothing.
+    AmountTooSmall = 5,
+    /// The payer is also listed as a recipient, which would make the transfer
+    /// partly a self-payment and misreport what each party received.
+    PayerIsRecipient = 6,
 }
 
-impl From<Error> for SplitterError {
-    fn from(e: Error) -> Self { SplitterError::ContractError(e) }
-}
-
+#[contract]
 pub struct PaymentSplitter;
 
 #[contractimpl]
 impl PaymentSplitter {
-    /// Splits `amount` equally among `recipients`.
-    /// Returns an error if amount is zero or any recipient is empty.
-    pub fn split(env: Env, amount: i128, recipients: Vec<Bytes>) -> Result<(), SplitterError> {
-        if amount <= 0 {
-            return Err(SplitterError::ZeroAmount);
+    /// Splits `amount` of `token_id` from `from` equally among `recipients`.
+    ///
+    /// The payer must authorise the call. Every recipient receives
+    /// `amount / n`, and the first `amount % n` recipients receive one
+    /// additional unit so that the distributed total is exactly `amount`.
+    ///
+    /// Validation runs before any transfer, so a rejected call moves no funds
+    /// at all rather than failing partway through.
+    pub fn split(
+        env: Env,
+        from: Address,
+        token_id: Address,
+        amount: i128,
+        recipients: Vec<Address>,
+    ) -> Result<(), Error> {
+        let shares = Self::split_shares(&env, amount, &recipients)?;
+
+        // Checked after the cheap validation, since it is the most expensive
+        // check in the list.
+        if recipients.contains(&from) {
+            return Err(Error::PayerIsRecipient);
         }
-        if recipients.is_empty() {
-            return Err(SplitterError::InvalidRecipient);
+
+        from.require_auth();
+
+        let client = token::Client::new(&env, &token_id);
+        for (index, recipient) in recipients.iter().enumerate() {
+            let share = shares.get(index as u32).unwrap_or(0);
+            client.transfer(&from, &recipient, &share);
         }
-        // Dummy logic: just verify recipients length divides amount
-        let share = amount / (recipients.len() as i128);
-        if share * (recipients.len() as i128) != amount {
-            // Not evenly divisible – still proceed for dummy
-        }
-        // In a real contract you would transfer `share` to each recipient here
+
         Ok(())
     }
+
+    /// Computes each recipient's share without moving any funds.
+    ///
+    /// Exposed so a caller can preview a split — and so the distribution logic
+    /// is testable without a token contract. The returned vector always sums to
+    /// exactly `amount`.
+    pub fn preview_split(
+        env: Env,
+        amount: i128,
+        recipients: Vec<Address>,
+    ) -> Result<Vec<i128>, Error> {
+        Self::split_shares(&env, amount, &recipients)
+    }
+
+    /// Validates the inputs and computes the per-recipient shares.
+    ///
+    /// The single place split arithmetic happens, so `split` and
+    /// `preview_split` can never disagree about who gets what.
+    fn split_shares(
+        env: &Env,
+        amount: i128,
+        recipients: &Vec<Address>,
+    ) -> Result<Vec<i128>, Error> {
+        if amount <= 0 {
+            return Err(Error::ZeroAmount);
+        }
+
+        let count = recipients.len();
+        if count == 0 {
+            return Err(Error::NoRecipients);
+        }
+        if count > MAX_RECIPIENTS {
+            return Err(Error::TooManyRecipients);
+        }
+
+        // A duplicate would receive two shares while the caller believes it
+        // received one, so the split would not match what the caller asked for.
+        // O(n^2), which is acceptable only because MAX_RECIPIENTS is bounded.
+        for i in 0..count {
+            let current = recipients.get(i).unwrap();
+            for j in (i + 1)..count {
+                if current == recipients.get(j).unwrap() {
+                    return Err(Error::DuplicateRecipient);
+                }
+            }
+        }
+
+        let count_i128 = count as i128;
+        if amount < count_i128 {
+            // Integer division would give at least one recipient zero. Better
+            // to reject than to transfer nothing and report success.
+            return Err(Error::AmountTooSmall);
+        }
+
+        let base = amount / count_i128;
+        let remainder = amount % count_i128;
+
+        // The remainder is distributed one unit at a time to the first
+        // `remainder` recipients rather than discarded. Deterministic, so the
+        // same inputs always produce the same allocation.
+        let mut shares = Vec::new(env);
+        for i in 0..count {
+            let extra = if (i as i128) < remainder { 1 } else { 0 };
+            shares.push_back(base + extra);
+        }
+
+        debug_assert_eq!(
+            shares.iter().sum::<i128>(),
+            amount,
+            "split must distribute the full amount"
+        );
+
+        Ok(shares)
+    }
 }
+
+#[cfg(test)]
+mod test;

--- a/contracts/payment_splitter/src/test.rs
+++ b/contracts/payment_splitter/src/test.rs
@@ -1,0 +1,220 @@
+#![cfg(test)]
+
+//! Tests for the Payment Splitter error handling (issue #999).
+//!
+//! Split arithmetic is exercised through `preview_split`, which needs no token
+//! contract — every case below is about *which* error comes back and whether
+//! the distribution conserves value.
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, vec, Env};
+
+fn setup() -> (Env, PaymentSplitterClient<'static>) {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PaymentSplitter);
+    let client = PaymentSplitterClient::new(&env, &contract_id);
+    (env, client)
+}
+
+fn addresses(env: &Env, n: u32) -> Vec<Address> {
+    let mut v = Vec::new(env);
+    for _ in 0..n {
+        v.push_back(Address::generate(env));
+    }
+    v
+}
+
+// ─── Even and uneven distribution ────────────────────────────────────────────
+
+#[test]
+fn splits_evenly_when_divisible() {
+    let (env, client) = setup();
+    let recipients = addresses(&env, 4);
+
+    let shares = client.preview_split(&100, &recipients);
+
+    assert_eq!(shares, vec![&env, 25, 25, 25, 25]);
+}
+
+#[test]
+fn distributes_remainder_instead_of_dropping_it() {
+    let (env, client) = setup();
+    let recipients = addresses(&env, 3);
+
+    // 100 / 3 = 33 remainder 1. The old implementation dropped that unit.
+    let shares = client.preview_split(&100, &recipients);
+
+    assert_eq!(shares, vec![&env, 34, 33, 33]);
+    assert_eq!(shares.iter().sum::<i128>(), 100, "no value may be lost");
+}
+
+#[test]
+fn conserves_value_for_every_remainder() {
+    let (env, client) = setup();
+    let recipients = addresses(&env, 7);
+
+    // Sweep every possible remainder for a 7-way split.
+    for amount in 7..=64i128 {
+        let shares = client.preview_split(&amount, &recipients);
+        assert_eq!(
+            shares.iter().sum::<i128>(),
+            amount,
+            "split of {amount} did not conserve value"
+        );
+        // No recipient may be starved while another is over-paid by more than
+        // the single remainder unit.
+        let min = shares.iter().min().unwrap();
+        let max = shares.iter().max().unwrap();
+        assert!(max - min <= 1, "shares for {amount} differ by more than one unit");
+    }
+}
+
+#[test]
+fn single_recipient_receives_everything() {
+    let (env, client) = setup();
+    let recipients = addresses(&env, 1);
+
+    assert_eq!(client.preview_split(&999, &recipients), vec![&env, 999]);
+}
+
+#[test]
+fn smallest_valid_amount_gives_each_recipient_one_unit() {
+    let (env, client) = setup();
+    let recipients = addresses(&env, 5);
+
+    assert_eq!(client.preview_split(&5, &recipients), vec![&env, 1, 1, 1, 1, 1]);
+}
+
+// ─── Error cases ─────────────────────────────────────────────────────────────
+
+#[test]
+fn rejects_zero_amount() {
+    let (env, client) = setup();
+    let recipients = addresses(&env, 2);
+
+    assert_eq!(
+        client.try_preview_split(&0, &recipients),
+        Err(Ok(Error::ZeroAmount))
+    );
+}
+
+#[test]
+fn rejects_negative_amount() {
+    let (env, client) = setup();
+    let recipients = addresses(&env, 2);
+
+    assert_eq!(
+        client.try_preview_split(&-1, &recipients),
+        Err(Ok(Error::ZeroAmount))
+    );
+}
+
+#[test]
+fn rejects_empty_recipient_list() {
+    let (env, client) = setup();
+
+    assert_eq!(
+        client.try_preview_split(&100, &Vec::new(&env)),
+        Err(Ok(Error::NoRecipients))
+    );
+}
+
+#[test]
+fn rejects_more_than_max_recipients() {
+    let (env, client) = setup();
+    let recipients = addresses(&env, MAX_RECIPIENTS + 1);
+
+    assert_eq!(
+        client.try_preview_split(&1_000_000, &recipients),
+        Err(Ok(Error::TooManyRecipients))
+    );
+}
+
+#[test]
+fn accepts_exactly_max_recipients() {
+    let (env, client) = setup();
+    let recipients = addresses(&env, MAX_RECIPIENTS);
+
+    // The boundary itself must be allowed — off-by-one here would silently cap
+    // splits one recipient short.
+    let shares = client.preview_split(&1_000_000, &recipients);
+    assert_eq!(shares.len(), MAX_RECIPIENTS);
+    assert_eq!(shares.iter().sum::<i128>(), 1_000_000);
+}
+
+#[test]
+fn rejects_duplicate_recipients() {
+    let (env, client) = setup();
+    let duplicate = Address::generate(&env);
+    let recipients = vec![&env, duplicate.clone(), Address::generate(&env), duplicate];
+
+    // A duplicate would quietly receive two shares while the caller believes
+    // it received one.
+    assert_eq!(
+        client.try_preview_split(&300, &recipients),
+        Err(Ok(Error::DuplicateRecipient))
+    );
+}
+
+#[test]
+fn rejects_amount_smaller_than_recipient_count() {
+    let (env, client) = setup();
+    let recipients = addresses(&env, 10);
+
+    // 9 / 10 == 0, so every recipient would get nothing and the call would
+    // still report success.
+    assert_eq!(
+        client.try_preview_split(&9, &recipients),
+        Err(Ok(Error::AmountTooSmall))
+    );
+}
+
+#[test]
+fn validation_order_reports_amount_before_recipients() {
+    let (env, client) = setup();
+
+    // Both inputs are invalid; the amount error is the more fundamental one and
+    // must be the one surfaced, so the message stays stable as callers fix
+    // their input.
+    assert_eq!(
+        client.try_preview_split(&0, &Vec::new(&env)),
+        Err(Ok(Error::ZeroAmount))
+    );
+}
+
+// ─── Transfer path ───────────────────────────────────────────────────────────
+
+#[test]
+fn rejects_payer_listed_as_recipient() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PaymentSplitter);
+    let client = PaymentSplitterClient::new(&env, &contract_id);
+
+    let payer = Address::generate(&env);
+    let token_id = Address::generate(&env);
+    let recipients = vec![&env, Address::generate(&env), payer.clone()];
+
+    env.mock_all_auths();
+
+    assert_eq!(
+        client.try_split(&payer, &token_id, &100, &recipients),
+        Err(Ok(Error::PayerIsRecipient))
+    );
+}
+
+#[test]
+fn split_validates_before_requiring_auth() {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PaymentSplitter);
+    let client = PaymentSplitterClient::new(&env, &contract_id);
+
+    let payer = Address::generate(&env);
+    let token_id = Address::generate(&env);
+
+    // No auth is mocked. A well-formed rejection proves validation ran first —
+    // if require_auth came earlier this would panic instead of returning.
+    assert_eq!(
+        client.try_split(&payer, &token_id, &0, &addresses(&env, 2)),
+        Err(Ok(Error::ZeroAmount))
+    );
+}


### PR DESCRIPTION
Closes #999

## Problem

The contract declared a `SplitterError` enum that **could never leave the contract**. It was a plain Rust enum rather than `#[contracterror]`, so it had no `u32` discriminant to encode into a failed invocation's result — a caller could not tell *"amount was zero"* from *"recipient list was empty"*, or from the contract panicking outright.

The struct was also missing `#[contract]` entirely, so `#[contractimpl]` had nothing to attach to, and the crate pinned `soroban-sdk = "0.10.0"` — four major versions behind every other contract here.

## Error model

Every failure mode is now a numbered variant, matching the convention the other contracts already use:

| Code | Variant | Cause |
|---|---|---|
| 1 | `ZeroAmount` | `amount <= 0` |
| 2 | `NoRecipients` | empty list |
| 3 | `TooManyRecipients` | beyond `MAX_RECIPIENTS` |
| 4 | `DuplicateRecipient` | same address twice |
| 5 | `AmountTooSmall` | `amount < recipient count` |
| 6 | `PayerIsRecipient` | payer also listed as a recipient |

## Conservation of value

This is the bug worth flagging. The previous implementation computed the division remainder, wrote a comment saying it would *"still proceed"* — and dropped it. Up to `n - 1` units silently lost on every uneven call.

**Splitting money must not lose money.** The remainder is now distributed deterministically: the first `remainder` recipients each receive one extra unit, so the shares always sum to exactly `amount`.

```
split(100, 3 recipients)  ->  [34, 33, 33]   (was [33, 33, 33], losing 1)
```

A test sweeps *every* remainder for a 7-way split and asserts both conservation and that no two shares differ by more than one unit.

## New edge cases

- **`amount < recipient count`** is rejected rather than transferring zero to everyone and reporting success.
- **Duplicate recipients** rejected — a duplicate would quietly take two shares while the caller believed it took one.
- **`MAX_RECIPIENTS`** bounds the loop. An unbounded list could exhaust the ledger's CPU budget mid-way, leaving a partial split with no record of where it stopped; rejecting up front keeps the call all-or-nothing.
- **Payer in its own recipient list** rejected, since it would make the transfer partly a self-payment and misreport what each party received.

Validation runs **before `require_auth` and before any transfer**, so a rejected call moves no funds and costs the caller no signature. There's a test for exactly that ordering.

## Also in this change

- Recipients are `Address` rather than `Bytes`, and the contract performs real token transfers instead of a comment saying a real one would
- `split_shares` is the single place split arithmetic happens, so `split` and the new `preview_split` can't disagree about who gets what
- `preview_split` lets a caller check a distribution before committing, and makes the arithmetic testable without a token contract
- `soroban-sdk` 0.10.0 → 20.0.0, matching every other contract here
- 15 tests covering distribution, boundaries, and each error variant

## On backwards compatibility

The issue asks for it, and I want to be explicit that I could not preserve the old signature: `split` previously took `Vec<Bytes>` and returned a non-encodable error, on an SDK version that no longer builds in this repo. There is no deployed ABI to keep compatible — the contract as written could not have been compiled or deployed at all. I've kept the function name and the conceptual shape; if you'd rather I add a shim or keep the old parameter types, say the word.

`payment_splitter` is not a workspace member, and I left it that way — `nft-marketplace` and `music-royalty` aren't either, so that appears intentional rather than an oversight.

## Verification

Per the constraints I was working under I did **not** run `cargo test` or `cargo build` on this. The logic is straightforward and the tests are written against the standard `try_*` client pattern, but two SDK-surface details deserve a compile check before merging: `Vec::contains` for the payer check, and `Vec::iter().enumerate()` in the transfer loop. If either isn't available in SDK 20 the fix is mechanical, and I'm glad to push it.
