### PR TITLE
refactor(upgradeable): remove duplicated contract and fix timelock arithmetic

### DIFF
--- a/contracts/upgradeable/src/lib.rs
+++ b/contracts/upgradeable/src/lib.rs
@@ -12,14 +12,20 @@
 //!    alongside the current ledger sequence.
 //! 3. After `timelock_ledgers` ledgers have elapsed, admin calls
 //!    `execute_upgrade` to apply the hash via `env.deployer().update_current_contract_wasm`.
-//! 4. Alternatively, admin calls `upgrade_to` (timelock = 0) for an immediate upgrade.
-//! 5. Admin may `pause`/`unpause` for emergency halts.
+//! 4. Alternatively, admin calls `upgrade_to`, an alias of `propose_upgrade`.
+//! 5. Admin may `cancel_upgrade` to withdraw a pending proposal.
+//! 6. Admin may `pause`/`unpause` for emergency halts.
 
 #![no_std]
 
 mod storage;
-mod test;
 mod types;
+
+// Gated so the test module is not compiled into the deployed WASM. It was
+// declared unconditionally; only the `#![cfg(test)]` inside test.rs kept it
+// from adding weight to release builds.
+#[cfg(test)]
+mod test;
 
 use soroban_sdk::{contract, contracterror, contractimpl, symbol_short, Address, BytesN, Env};
 
@@ -120,7 +126,13 @@ impl UpgradeableContract {
         let timelock = get_timelock(&env);
         let current = env.ledger().sequence();
 
-        if current < proposed_at + timelock {
+        // saturating_add, not `+`: both operands are u32, and a large timelock
+        // proposed at a high ledger sequence overflows. Release builds here set
+        // overflow-checks = true, so that would panic — aborting the invocation
+        // with no error code instead of reporting TimelockNotElapsed. Saturating
+        // keeps the comparison correct, since an unreachable deadline should
+        // simply never elapse.
+        if current < proposed_at.saturating_add(timelock) {
             return Err(Error::TimelockNotElapsed);
         }
 
@@ -130,9 +142,36 @@ impl UpgradeableContract {
         Ok(())
     }
 
-    /// Convenience: immediate upgrade (requires timelock == 0).
+    /// Alias for [`Self::propose_upgrade`].
+    ///
+    /// Applies `new_hash` immediately when the timelock is 0, and otherwise
+    /// records it as pending — it does *not* bypass a configured timelock. The
+    /// previous doc comment said "requires timelock == 0", which read as though
+    /// the call would fail on a timelocked contract; it never did, it silently
+    /// proposed instead. Behaviour is unchanged, the description now matches it.
     pub fn upgrade_to(env: Env, admin: Address, new_hash: BytesN<32>) -> Result<(), Error> {
         Self::propose_upgrade(env, admin, new_hash)
+    }
+
+    /// Withdraw a pending upgrade without executing it. Admin-only.
+    ///
+    /// Previously a proposal could only be replaced, never cancelled: once a
+    /// hash was pending, the only way out was to propose a different one, and a
+    /// contract could not be returned to a clean state. That matters when a
+    /// proposal turns out to be wrong — leaving it pending means it stays
+    /// executable the moment the timelock elapses.
+    ///
+    /// Permitted while paused: cancelling only removes a pending action, so
+    /// blocking it during an emergency halt would be exactly backwards.
+    pub fn cancel_upgrade(env: Env, admin: Address) -> Result<(), Error> {
+        ensure_initialized(&env)?;
+        admin.require_auth();
+        require_admin(&env, &admin)?;
+
+        let (hash, _) = get_pending_upgrade(&env).ok_or(Error::NoPendingUpgrade)?;
+        clear_pending_upgrade(&env);
+        env.events().publish((symbol_short!("cancelled"),), hash);
+        Ok(())
     }
 
     // ── Read-only ─────────────────────────────────────────────────────────────
@@ -180,147 +219,4 @@ fn require_admin(env: &Env, caller: &Address) -> Result<(), Error> {
         return Err(Error::Unauthorized);
     }
     Ok(())
-}
-
-
-#![no_std]
-use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env,
-    Symbol,
-};
-
-const TIMELOCK_DELAY_SECONDS: u64 = 172_800; // 48 Hours
-
-#[contracterror]
-#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
-#[repr(u32)]
-pub enum UpgradeError {
-    NotAdmin = 1,
-    ContractPaused = 2,
-    NoUpgradeProposed = 3,
-    TimelockNotExpired = 4,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PendingUpgrade {
-    pub new_wasm_hash: BytesN<32>,
-    pub eta: u64,
-}
-
-#[contracttype]
-pub enum DataKey {
-    Admin,
-    Paused,
-    PendingUpgrade,
-}
-
-#[contract]
-pub struct UpgradeableContract;
-
-#[contractimpl]
-impl UpgradeableContract {
-    /// Initialize the contract with an admin authority
-    pub fn initialize(env: Env, admin: Address) {
-        if env.storage().instance().has(&DataKey::Admin) {
-            panic!("Already initialized");
-        }
-        admin.require_auth();
-        env.storage().instance().set(&DataKey::Admin, &admin);
-        env.storage().instance().set(&DataKey::Paused, &false);
-    }
-
-    /// Admin proposes a new WASM hash subject to the 48-hour timelock
-    pub fn propose_upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), UpgradeError> {
-        let admin = Self::get_admin(&env)?;
-        admin.require_auth();
-        Self::ensure_not_paused(&env)?;
-
-        let current_time = env.ledger().timestamp();
-        let eta = current_time + TIMELOCK_DELAY_SECONDS;
-
-        let pending = PendingUpgrade {
-            new_wasm_hash: new_wasm_hash.clone(),
-            eta,
-        };
-
-        env.storage()
-            .instance()
-            .set(&DataKey::PendingUpgrade, &pending);
-
-        env.events().publish(
-            (symbol_short!("upgrade"), symbol_short!("proposed")),
-            (new_wasm_hash, eta),
-        );
-
-        Ok(())
-    }
-
-    /// Execute proposed upgrade once timelock delay has elapsed
-    pub fn execute_upgrade(env: Env) -> Result<(), UpgradeError> {
-        let admin = Self::get_admin(&env)?;
-        admin.require_auth();
-        Self::ensure_not_paused(&env)?;
-
-        let pending: PendingUpgrade = env
-            .storage()
-            .instance()
-            .get(&DataKey::PendingUpgrade)
-            .ok_or(UpgradeError::NoUpgradeProposed)?;
-
-        let current_time = env.ledger().timestamp();
-        if current_time < pending.eta {
-            return Err(UpgradeError::TimelockNotExpired);
-        }
-
-        // Apply WASM code update via Soroban SDK deployer
-        env.deployer()
-            .update_current_contract_wasm(pending.new_wasm_hash.clone());
-
-        env.storage().instance().remove(&DataKey::PendingUpgrade);
-
-        env.events().publish(
-            (symbol_short!("upgrade"), symbol_short!("executed")),
-            pending.new_wasm_hash,
-        );
-
-        Ok(())
-    }
-
-    /// Toggle emergency pause status immediately
-    pub fn set_paused(env: Env, paused: bool) -> Result<(), UpgradeError> {
-        let admin = Self::get_admin(&env)?;
-        admin.require_auth();
-
-        env.storage().instance().set(&DataKey::Paused, &paused);
-
-        env.events().publish(
-            (symbol_short!("pause"), Symbol::new(&env, "toggled")),
-            paused,
-        );
-
-        Ok(())
-    }
-
-    /// Helper to fetch admin or fail
-    pub fn get_admin(env: &Env) -> Result<Address, UpgradeError> {
-        env.storage()
-            .instance()
-            .get(&DataKey::Admin)
-            .ok_or(UpgradeError::NotAdmin)
-    }
-
-    /// Helper to enforce active state
-    fn ensure_not_paused(env: &Env) -> Result<(), UpgradeError> {
-        let is_paused: bool = env
-            .storage()
-            .instance()
-            .get(&DataKey::Paused)
-            .unwrap_or(false);
-
-        if is_paused {
-            return Err(UpgradeError::ContractPaused);
-        }
-        Ok(())
-    }
 }

--- a/contracts/upgradeable/src/test.rs
+++ b/contracts/upgradeable/src/test.rs
@@ -226,43 +226,92 @@ fn test_ledger_sequence_advances() {
     // An InvokeError (host error) also means timelock was passed → test passes.
 }
 
+// ── cancel_upgrade (issue #998) ───────────────────────────────────────────────
 
-#[cfg(test)]
-mod tests {
-    use crate::{UpgradeableContract, UpgradeableContractClient, UpgradeError};
-    use soroban_sdk::{testutils::Address as _, Address, BytesN, Env};
+#[test]
+fn test_cancel_upgrade_clears_pending() {
+    let (env, admin, client) = setup();
+    client.try_initialize(&admin, &Some(100u32)).unwrap();
 
-    #[test]
-    fn test_timelock_and_emergency_pause() {
-        let env = Env::default();
-        env.mock_all_signatures();
+    let hash = BytesN::from_array(&env, &[7u8; 32]);
+    client.try_propose_upgrade(&admin, &hash).unwrap();
+    assert!(client.get_pending_upgrade().is_some());
 
-        let contract_id = env.register_contract(None, UpgradeableContract);
-        let client = UpgradeableContractClient::new(&env, &contract_id);
+    client.try_cancel_upgrade(&admin).unwrap();
 
-        let admin = Address::generate(&env);
-        client.initialize(&admin);
+    // A withdrawn proposal must not remain executable once the timelock lapses.
+    assert!(client.get_pending_upgrade().is_none());
+}
 
-        let mock_wasm_hash = BytesN::from_array(&env, &[1u8; 32]);
+#[test]
+fn test_cancel_upgrade_without_pending_fails() {
+    let (_env, admin, client) = setup();
+    client.try_initialize(&admin, &Some(100u32)).unwrap();
 
-        // 1. Propose Upgrade
-        client.propose_upgrade(&mock_wasm_hash);
+    assert_eq!(
+        client.try_cancel_upgrade(&admin).unwrap_err().unwrap(),
+        Error::NoPendingUpgrade
+    );
+}
 
-        // 2. Early Execution Failure (Timelock not expired)
-        let result = client.try_execute_upgrade();
-        assert_eq!(result, Err(Ok(UpgradeError::TimelockNotExpired)));
+#[test]
+fn test_non_admin_cannot_cancel_upgrade() {
+    let (env, admin, client) = setup();
+    client.try_initialize(&admin, &Some(100u32)).unwrap();
 
-        // 3. Fast-forward ledger timestamp past 48 hours (172,800 seconds)
-        env.ledger().set_timestamp(172_801);
+    let hash = BytesN::from_array(&env, &[7u8; 32]);
+    client.try_propose_upgrade(&admin, &hash).unwrap();
 
-        // 4. Test Emergency Pause Gating
-        client.set_paused(&true);
-        let pause_result = client.try_execute_upgrade();
-        assert_eq!(pause_result, Err(Ok(UpgradeError::ContractPaused)));
+    let other = Address::generate(&env);
+    assert_eq!(
+        client.try_cancel_upgrade(&other).unwrap_err().unwrap(),
+        Error::Unauthorized
+    );
+    assert!(client.get_pending_upgrade().is_some(), "proposal was cleared by a non-admin");
+}
 
-        // 5. Unpause and execute successfully
-        client.set_paused(&false);
-        let exec_result = client.try_execute_upgrade();
-        assert!(exec_result.is_ok());
-    }
+#[test]
+fn test_cancel_upgrade_allowed_while_paused() {
+    let (env, admin, client) = setup();
+    client.try_initialize(&admin, &Some(100u32)).unwrap();
+
+    let hash = BytesN::from_array(&env, &[7u8; 32]);
+    client.try_propose_upgrade(&admin, &hash).unwrap();
+    client.try_pause(&admin).unwrap();
+
+    // Cancelling only removes a pending action, so blocking it during an
+    // emergency halt would be exactly backwards.
+    client.try_cancel_upgrade(&admin).unwrap();
+    assert!(client.get_pending_upgrade().is_none());
+}
+
+#[test]
+fn test_cancel_upgrade_before_init_fails() {
+    let (env, _admin, client) = setup();
+    let caller = Address::generate(&env);
+
+    assert_eq!(
+        client.try_cancel_upgrade(&caller).unwrap_err().unwrap(),
+        Error::NotInitialized
+    );
+}
+
+// ── Timelock deadline arithmetic (issue #998) ─────────────────────────────────
+
+#[test]
+fn test_execute_does_not_overflow_with_max_timelock() {
+    let (env, admin, client) = setup();
+    // A timelock near u32::MAX makes `proposed_at + timelock` overflow. With
+    // overflow-checks enabled in release that aborts the invocation instead of
+    // returning an error code; saturating_add keeps it a normal rejection.
+    client.try_initialize(&admin, &Some(u32::MAX)).unwrap();
+
+    let hash = BytesN::from_array(&env, &[9u8; 32]);
+    client.try_propose_upgrade(&admin, &hash).unwrap();
+
+    assert_eq!(
+        client.try_execute_upgrade(&admin).unwrap_err().unwrap(),
+        Error::TimelockNotElapsed,
+        "an unreachable deadline should never elapse, not panic"
+    );
 }


### PR DESCRIPTION
Closes #998

## The headline problem: the crate doesn't compile

`lib.rs` contained **two entire contracts concatenated together**. Lines 186–326 were a second, unrelated implementation pasted in below the first:

- a duplicate `#[contract] pub struct UpgradeableContract;` (E0428)
- a duplicate `#[contractimpl] impl UpgradeableContract` re-defining `initialize`, `propose_upgrade`, `execute_upgrade` and `get_admin`
- an inner `#![no_std]` attribute **at line 186** — inner attributes are only valid at the top of a file
- a `pub fn get_admin(env: &Env)` inside a `#[contractimpl]` block, which can't be a contract function; entry points take `Env` by value

`test.rs` had the same problem — an orphaned `mod tests` at the end exercising the *second* implementation's API (one-argument `initialize`, argument-less `propose_upgrade`) and calling `env.mock_all_signatures()`, which doesn't exist in SDK 20.

### Which one survives

The first implementation, because it's the one the rest of the crate is built around: `storage.rs`, `types.rs` and the other 20 tests all target its ledger-sequence timelock and its typed `Error` enum. The orphan had no supporting modules at all — it was self-contained dead code that broke the build for everything else.

## Timelock deadline overflow

`execute_upgrade` compared `current < proposed_at + timelock` on two `u32` values. A large timelock proposed at a high ledger sequence overflows — and this crate's release profile sets `overflow-checks = true`, so instead of returning `TimelockNotElapsed` the invocation would **abort with no error code at all**.

Now `saturating_add`: an unreachable deadline simply never elapses, which is the correct reading of it. Covered by a test at `u32::MAX`.

## New: `cancel_upgrade`

A pending proposal could only be *replaced*, never withdrawn. Once a hash was pending, the only way out was to propose a different one — a contract couldn't be returned to a clean state, and a proposal that turned out to be wrong **stayed executable the moment its timelock elapsed**.

`cancel_upgrade` is admin-only and deliberately **permitted while paused**: cancelling only removes a pending action, so blocking it during an emergency halt would be exactly backwards.

## Smaller cleanups

- `mod test` is now `#[cfg(test)]` gated rather than declared unconditionally
- `upgrade_to`'s doc said it *"requires timelock == 0"*, which read as though it would fail on a timelocked contract. It never did — it silently proposed instead. Behaviour unchanged; the description now matches it.

## Backwards compatibility

**No existing public API changed.** `get_pending_upgrade` still returns `Option<(BytesN<32>, u32)>` rather than the nicer struct the orphan used, specifically so the existing tests and any callers keep working. All 20 existing tests are untouched; 6 new ones cover cancellation, its authorisation, its behaviour while paused and before init, and the deadline overflow.

## Verification

Per the constraints I was working under I did not run `cargo test` — which is worth noting twice here, because the whole point of this PR is that the crate previously *couldn't* be compiled. I'd expect `cargo build -p upgradeable` to go from "fails" to "passes" as the first thing to check on review; if anything still fails after removing the orphan, I'd like to know and will fix it.
