### PR TITLE
refactor(music-royalty): specific errors, checked arithmetic, and a test suite

### DIFF
--- a/contracts/music-royalty/Cargo.toml
+++ b/contracts/music-royalty/Cargo.toml
@@ -5,10 +5,15 @@ edition = "2021"
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+# rlib alongside cdylib so the crate can be linked into a test harness; a
+# cdylib-only crate cannot be unit tested.
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 soroban-sdk = "20.0.0"
+
+[dev-dependencies]
+soroban-sdk = { version = "20.0.0", features = ["testutils"] }
 
 [profile.release]
 opt-level = "z"

--- a/contracts/music-royalty/src/lib.rs
+++ b/contracts/music-royalty/src/lib.rs
@@ -3,6 +3,9 @@
 mod storage;
 mod types;
 
+#[cfg(test)]
+mod test;
+
 use soroban_sdk::{contract, contractimpl, symbol_short, Address, Env, String, Vec};
 use crate::storage::{
     get_song, is_initialized, set_initialized, set_song, get_usage_record, set_usage_record,
@@ -49,16 +52,15 @@ impl MusicRoyalty {
     ) -> Result<(), Error> {
         artist.require_auth();
         
-        // Validate song ID
         if id.len() == 0 || id.len() > MAX_SONG_ID_LENGTH {
-            return Err(Error::InvalidSplits);
+            return Err(Error::InvalidSongId);
         }
-        
-        // Validate title
+
         if title.len() == 0 || title.len() > MAX_TITLE_LENGTH {
-            return Err(Error::InvalidSplits);
+            return Err(Error::InvalidTitle);
         }
-        
+
+
         // Validate splits total 10000 (100%)
         let total_share = self::validate_splits(&splits)?;
         if total_share != TOTAL_SHARE_BASIS_POINTS {
@@ -87,7 +89,14 @@ impl MusicRoyalty {
         // In a real contract, we would actually transfer funds here
         // for each split.account. For the playground, we just track it.
         
-        song.total_royalty_earned += amount;
+        // checked_add on every running total in this contract: these are
+        // lifetime accumulators that only ever grow, and this crate's release
+        // profile sets overflow-checks = true, so an unchecked `+=` would abort
+        // the invocation with no error code once a total saturated.
+        song.total_royalty_earned = song
+            .total_royalty_earned
+            .checked_add(amount)
+            .ok_or(Error::Overflow)?;
         set_song(&env, song_id, &song);
         Ok(())
     }
@@ -117,6 +126,12 @@ impl MusicRoyalty {
         validate_license_params(&license_type, royalty_rate, duration_seconds)?;
         
         let now = env.ledger().timestamp();
+        // A duration near u64::MAX would overflow the expiry. MAX_LICENSE_DURATION
+        // already bounds it, but relying on a validation elsewhere to prevent an
+        // arithmetic panic here is exactly the coupling that breaks when someone
+        // later raises the constant.
+        let expires_at = now.checked_add(duration_seconds).ok_or(Error::Overflow)?;
+
         let license = License {
             song_id: song_id.clone(),
             licensee: licensee.clone(),
@@ -124,7 +139,7 @@ impl MusicRoyalty {
             royalty_rate,
             active: true,
             created_at: now,
-            expires_at: now + duration_seconds,
+            expires_at,
         };
         
         set_license(&env, song_id.clone(), licensee.clone(), &license);
@@ -160,9 +175,11 @@ impl MusicRoyalty {
             return Err(Error::ZeroAmount);
         }
         
-        // Verify license is active
+        // LicenseNotFound rather than SongNotFound: the song may well exist and
+        // simply have no license for this licensee, and reporting the song as
+        // missing sends a caller looking in the wrong place.
         let license = get_license(&env, song_id.clone(), licensee.clone())
-            .ok_or(Error::SongNotFound)?;
+            .ok_or(Error::LicenseNotFound)?;
         
         let current_time = env.ledger().timestamp();
         if !is_license_active(&license, current_time) {
@@ -179,16 +196,28 @@ impl MusicRoyalty {
                 last_payment_timestamp: 0,
             });
         
-        record.usage_count += usage_count;
-        record.total_paid += payment_amount;
+        record.usage_count = record
+            .usage_count
+            .checked_add(usage_count)
+            .ok_or(Error::Overflow)?;
+        record.total_paid = record
+            .total_paid
+            .checked_add(payment_amount)
+            .ok_or(Error::Overflow)?;
         record.last_payment_timestamp = current_time;
-        
+
         set_usage_record(&env, song_id.clone(), licensee.clone(), &record);
-        
+
         // Update revenue share
         if let Some(mut share) = get_revenue_share(&env, song_id.clone()) {
-            share.total_revenue += payment_amount;
-            share.pending_distribution += payment_amount;
+            share.total_revenue = share
+                .total_revenue
+                .checked_add(payment_amount)
+                .ok_or(Error::Overflow)?;
+            share.pending_distribution = share
+                .pending_distribution
+                .checked_add(payment_amount)
+                .ok_or(Error::Overflow)?;
             set_revenue_share(&env, song_id.clone(), &share);
         }
         
@@ -214,7 +243,10 @@ impl MusicRoyalty {
         
         // In a real contract, we would transfer funds to each split recipient
         // For now, we just track the distribution
-        share.distributed_revenue += amount_to_distribute;
+        share.distributed_revenue = share
+            .distributed_revenue
+            .checked_add(amount_to_distribute)
+            .ok_or(Error::Overflow)?;
         share.pending_distribution = 0;
         share.last_distribution_timestamp = env.ledger().timestamp();
         
@@ -244,34 +276,52 @@ impl MusicRoyalty {
         song_id: String,
         licensee: Address,
     ) -> Result<License, Error> {
-        get_license(&env, song_id, licensee).ok_or(Error::SongNotFound)
+        get_license(&env, song_id, licensee).ok_or(Error::LicenseNotFound)
     }
 }
 
 // ── Private Helper Functions ─────────────────────────────────────────────────────
 
-/// Validate that splits sum to 100% and each split is valid
+/// Validate that splits sum to 100%, each split is valid, and no account repeats.
+///
+/// The emptiness check now runs *first*. It previously sat after the loop,
+/// where it could only ever be reached with `total_share == 0` — the guard was
+/// correct but unreachable-looking, and reading it required proving the loop
+/// body never ran.
 fn validate_splits(splits: &Vec<Split>) -> Result<u32, Error> {
-    let mut total_share: u32 = 0;
-    
-    for split in splits.iter() {
-        // Validate individual split share
-        if split.share == 0 || split.share > TOTAL_SHARE_BASIS_POINTS {
-            return Err(Error::InvalidSplits);
-        }
-        total_share += split.share;
-        
-        // Check for overflow
-        if total_share > TOTAL_SHARE_BASIS_POINTS {
-            return Err(Error::InvalidSplits);
-        }
-    }
-    
-    // Ensure at least one split exists
     if splits.is_empty() {
         return Err(Error::InvalidSplits);
     }
-    
+
+    let mut total_share: u32 = 0;
+
+    for (i, split) in splits.iter().enumerate() {
+        if split.share == 0 || split.share > TOTAL_SHARE_BASIS_POINTS {
+            return Err(Error::InvalidSplits);
+        }
+
+        // checked_add, not `+=`: the previous code added first and range-checked
+        // afterwards, so a long enough split table would overflow u32 before the
+        // bound was ever tested. The comment there said "Check for overflow" but
+        // it checked the 10000 bound, which is a different thing.
+        total_share = total_share
+            .checked_add(split.share)
+            .ok_or(Error::Overflow)?;
+
+        if total_share > TOTAL_SHARE_BASIS_POINTS {
+            return Err(Error::InvalidSplits);
+        }
+
+        // A repeated account silently collects two shares while the artist
+        // believes it holds one. O(n^2), which is affordable because the shares
+        // must sum to 10000 and each is at least 1, capping the table length.
+        for j in (i + 1)..(splits.len() as usize) {
+            if split.account == splits.get(j as u32).unwrap().account {
+                return Err(Error::DuplicateSplitAccount);
+            }
+        }
+    }
+
     Ok(total_share)
 }
 
@@ -281,21 +331,21 @@ fn validate_license_params(
     royalty_rate: u32,
     duration_seconds: u64,
 ) -> Result<(), Error> {
-    // Validate license type length
+    // Each failure now reports what actually failed. These all returned
+    // InvalidSplits before, which told a caller their split table was wrong
+    // when the split table was fine.
     if license_type.len() == 0 || license_type.len() > MAX_LICENSE_TYPE_LENGTH {
-        return Err(Error::InvalidSplits);
+        return Err(Error::InvalidLicenseType);
     }
-    
-    // Validate royalty rate
+
     if royalty_rate < MIN_ROYALTY_RATE || royalty_rate > MAX_ROYALTY_RATE {
-        return Err(Error::InvalidSplits);
+        return Err(Error::InvalidRoyaltyRate);
     }
-    
-    // Validate duration
+
     if duration_seconds < MIN_LICENSE_DURATION || duration_seconds > MAX_LICENSE_DURATION {
-        return Err(Error::InvalidSplits);
+        return Err(Error::InvalidDuration);
     }
-    
+
     Ok(())
 }
 

--- a/contracts/music-royalty/src/test.rs
+++ b/contracts/music-royalty/src/test.rs
@@ -1,0 +1,441 @@
+// Copyright (c) 2026 StellarDevTools
+// SPDX-License-Identifier: MIT
+
+#![cfg(test)]
+
+//! Tests for the Royalty Distributor refactor (issue #1001).
+//!
+//! The contract had no tests at all, so the refactor had nothing holding it in
+//! place. These pin the behaviour that changed — specific error variants,
+//! duplicate-account rejection, checked accumulators — plus the happy paths
+//! they had to keep working.
+
+use super::*;
+use soroban_sdk::{testutils::Address as _, vec, Env, String as SdkString};
+
+const HOUR: u64 = 3_600;
+
+fn setup() -> (Env, MusicRoyaltyClient<'static>, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let id = env.register_contract(None, MusicRoyalty);
+    let client = MusicRoyaltyClient::new(&env, &id);
+    client.initialize();
+    let artist = Address::generate(&env);
+    (env, client, artist)
+}
+
+fn even_splits(env: &Env, n: u32) -> Vec<Split> {
+    let mut splits = Vec::new(env);
+    let share = TOTAL_SHARE_BASIS_POINTS / n;
+    let mut allocated = 0;
+    for i in 0..n {
+        // Last split absorbs the rounding so the table still totals 10000.
+        let s = if i == n - 1 { TOTAL_SHARE_BASIS_POINTS - allocated } else { share };
+        allocated += s;
+        splits.push_back(Split {
+            account: Address::generate(env),
+            share: s,
+        });
+    }
+    splits
+}
+
+fn register(client: &MusicRoyaltyClient, env: &Env, artist: &Address, id: &str) {
+    client.register_song(
+        artist,
+        &SdkString::from_str(env, id),
+        &SdkString::from_str(env, "Title"),
+        &even_splits(env, 2),
+    );
+}
+
+// ── Initialization ────────────────────────────────────────────────────────────
+
+#[test]
+fn initialize_is_once_only() {
+    let (_env, client, _artist) = setup();
+    assert_eq!(
+        client.try_initialize().unwrap_err().unwrap(),
+        Error::AlreadyInitialized
+    );
+}
+
+// ── Split validation ──────────────────────────────────────────────────────────
+
+#[test]
+fn registers_song_with_valid_splits() {
+    let (env, client, artist) = setup();
+    register(&client, &env, &artist, "song-1");
+
+    let song = client.get_song_info(&SdkString::from_str(&env, "song-1"));
+    assert_eq!(song.total_royalty_earned, 0);
+    assert_eq!(song.splits.len(), 2);
+}
+
+#[test]
+fn rejects_empty_split_table() {
+    let (env, client, artist) = setup();
+    assert_eq!(
+        client
+            .try_register_song(
+                &artist,
+                &SdkString::from_str(&env, "s"),
+                &SdkString::from_str(&env, "T"),
+                &Vec::new(&env),
+            )
+            .unwrap_err()
+            .unwrap(),
+        Error::InvalidSplits
+    );
+}
+
+#[test]
+fn rejects_splits_that_do_not_total_100_percent() {
+    let (env, client, artist) = setup();
+    let splits = vec![
+        &env,
+        Split { account: Address::generate(&env), share: 5_000 },
+        Split { account: Address::generate(&env), share: 4_000 },
+    ];
+
+    assert_eq!(
+        client
+            .try_register_song(
+                &artist,
+                &SdkString::from_str(&env, "s"),
+                &SdkString::from_str(&env, "T"),
+                &splits,
+            )
+            .unwrap_err()
+            .unwrap(),
+        Error::InvalidSplits
+    );
+}
+
+#[test]
+fn rejects_duplicate_split_accounts() {
+    let (env, client, artist) = setup();
+    let repeated = Address::generate(&env);
+    let splits = vec![
+        &env,
+        Split { account: repeated.clone(), share: 5_000 },
+        Split { account: repeated, share: 5_000 },
+    ];
+
+    // The table totals 10000 and every share is in range, so this was accepted
+    // before the refactor — the repeated account collected both shares while
+    // the artist believed it held one.
+    assert_eq!(
+        client
+            .try_register_song(
+                &artist,
+                &SdkString::from_str(&env, "s"),
+                &SdkString::from_str(&env, "T"),
+                &splits,
+            )
+            .unwrap_err()
+            .unwrap(),
+        Error::DuplicateSplitAccount
+    );
+}
+
+#[test]
+fn rejects_zero_share_split() {
+    let (env, client, artist) = setup();
+    let splits = vec![
+        &env,
+        Split { account: Address::generate(&env), share: 10_000 },
+        Split { account: Address::generate(&env), share: 0 },
+    ];
+
+    assert_eq!(
+        client
+            .try_register_song(
+                &artist,
+                &SdkString::from_str(&env, "s"),
+                &SdkString::from_str(&env, "T"),
+                &splits,
+            )
+            .unwrap_err()
+            .unwrap(),
+        Error::InvalidSplits
+    );
+}
+
+// ── Specific error variants (the core of #1001) ───────────────────────────────
+
+#[test]
+fn empty_song_id_reports_invalid_song_id_not_invalid_splits() {
+    let (env, client, artist) = setup();
+    assert_eq!(
+        client
+            .try_register_song(
+                &artist,
+                &SdkString::from_str(&env, ""),
+                &SdkString::from_str(&env, "T"),
+                &even_splits(&env, 2),
+            )
+            .unwrap_err()
+            .unwrap(),
+        Error::InvalidSongId,
+        "a bad song id must not be reported as a split problem"
+    );
+}
+
+#[test]
+fn empty_title_reports_invalid_title_not_invalid_splits() {
+    let (env, client, artist) = setup();
+    assert_eq!(
+        client
+            .try_register_song(
+                &artist,
+                &SdkString::from_str(&env, "s"),
+                &SdkString::from_str(&env, ""),
+                &even_splits(&env, 2),
+            )
+            .unwrap_err()
+            .unwrap(),
+        Error::InvalidTitle
+    );
+}
+
+#[test]
+fn bad_royalty_rate_reports_invalid_royalty_rate() {
+    let (env, client, artist) = setup();
+    register(&client, &env, &artist, "s");
+
+    assert_eq!(
+        client
+            .try_issue_license(
+                &artist,
+                &SdkString::from_str(&env, "s"),
+                &Address::generate(&env),
+                &SdkString::from_str(&env, "streaming"),
+                &(MAX_ROYALTY_RATE + 1),
+                &(24 * HOUR),
+            )
+            .unwrap_err()
+            .unwrap(),
+        Error::InvalidRoyaltyRate
+    );
+}
+
+#[test]
+fn bad_duration_reports_invalid_duration() {
+    let (env, client, artist) = setup();
+    register(&client, &env, &artist, "s");
+
+    assert_eq!(
+        client
+            .try_issue_license(
+                &artist,
+                &SdkString::from_str(&env, "s"),
+                &Address::generate(&env),
+                &SdkString::from_str(&env, "streaming"),
+                &500,
+                &(MIN_LICENSE_DURATION - 1),
+            )
+            .unwrap_err()
+            .unwrap(),
+        Error::InvalidDuration
+    );
+}
+
+#[test]
+fn empty_license_type_reports_invalid_license_type() {
+    let (env, client, artist) = setup();
+    register(&client, &env, &artist, "s");
+
+    assert_eq!(
+        client
+            .try_issue_license(
+                &artist,
+                &SdkString::from_str(&env, "s"),
+                &Address::generate(&env),
+                &SdkString::from_str(&env, ""),
+                &500,
+                &(24 * HOUR),
+            )
+            .unwrap_err()
+            .unwrap(),
+        Error::InvalidLicenseType
+    );
+}
+
+#[test]
+fn missing_license_reports_license_not_found_not_song_not_found() {
+    let (env, client, artist) = setup();
+    register(&client, &env, &artist, "s");
+
+    // The song exists; only the license is missing. Reporting SongNotFound sent
+    // callers looking in the wrong place.
+    assert_eq!(
+        client
+            .try_record_usage(
+                &SdkString::from_str(&env, "s"),
+                &Address::generate(&env),
+                &1,
+                &100,
+            )
+            .unwrap_err()
+            .unwrap(),
+        Error::LicenseNotFound
+    );
+}
+
+// ── Licensing and usage ───────────────────────────────────────────────────────
+
+#[test]
+fn records_usage_and_accumulates_revenue() {
+    let (env, client, artist) = setup();
+    let licensee = Address::generate(&env);
+    let song_id = SdkString::from_str(&env, "s");
+    register(&client, &env, &artist, "s");
+
+    client.issue_license(
+        &artist,
+        &song_id,
+        &licensee,
+        &SdkString::from_str(&env, "streaming"),
+        &500,
+        &(24 * HOUR),
+    );
+
+    client.record_usage(&song_id, &licensee, &3, &1_000);
+    client.record_usage(&song_id, &licensee, &2, &500);
+
+    let stats = client.get_usage_stats(&song_id, &licensee);
+    assert_eq!(stats.usage_count, 5);
+    assert_eq!(stats.total_paid, 1_500);
+
+    let revenue = client.get_revenue_info(&song_id);
+    assert_eq!(revenue.total_revenue, 1_500);
+    assert_eq!(revenue.pending_distribution, 1_500);
+}
+
+#[test]
+fn rejects_usage_on_expired_license() {
+    let (env, client, artist) = setup();
+    let licensee = Address::generate(&env);
+    let song_id = SdkString::from_str(&env, "s");
+    register(&client, &env, &artist, "s");
+
+    client.issue_license(
+        &artist,
+        &song_id,
+        &licensee,
+        &SdkString::from_str(&env, "streaming"),
+        &500,
+        &(2 * HOUR),
+    );
+
+    env.ledger().with_mut(|l| l.timestamp += 3 * HOUR);
+
+    assert_eq!(
+        client
+            .try_record_usage(&song_id, &licensee, &1, &100)
+            .unwrap_err()
+            .unwrap(),
+        Error::Unauthorized
+    );
+}
+
+#[test]
+fn rejects_zero_usage_or_payment() {
+    let (env, client, artist) = setup();
+    let licensee = Address::generate(&env);
+    let song_id = SdkString::from_str(&env, "s");
+    register(&client, &env, &artist, "s");
+    client.issue_license(
+        &artist,
+        &song_id,
+        &licensee,
+        &SdkString::from_str(&env, "streaming"),
+        &500,
+        &(24 * HOUR),
+    );
+
+    assert_eq!(
+        client.try_record_usage(&song_id, &licensee, &0, &100).unwrap_err().unwrap(),
+        Error::ZeroAmount
+    );
+    assert_eq!(
+        client.try_record_usage(&song_id, &licensee, &1, &0).unwrap_err().unwrap(),
+        Error::ZeroAmount
+    );
+}
+
+// ── Distribution ──────────────────────────────────────────────────────────────
+
+#[test]
+fn distributes_pending_revenue_and_resets_it() {
+    let (env, client, artist) = setup();
+    let licensee = Address::generate(&env);
+    let song_id = SdkString::from_str(&env, "s");
+    register(&client, &env, &artist, "s");
+    client.issue_license(
+        &artist,
+        &song_id,
+        &licensee,
+        &SdkString::from_str(&env, "streaming"),
+        &500,
+        &(24 * HOUR),
+    );
+    client.record_usage(&song_id, &licensee, &1, &2_000);
+
+    assert_eq!(client.distribute_royalties(&song_id), 2_000);
+
+    let revenue = client.get_revenue_info(&song_id);
+    assert_eq!(revenue.distributed_revenue, 2_000);
+    assert_eq!(revenue.pending_distribution, 0, "pending must be cleared");
+}
+
+#[test]
+fn rejects_distribution_with_nothing_pending() {
+    let (env, client, artist) = setup();
+    let licensee = Address::generate(&env);
+    let song_id = SdkString::from_str(&env, "s");
+    register(&client, &env, &artist, "s");
+    client.issue_license(
+        &artist,
+        &song_id,
+        &licensee,
+        &SdkString::from_str(&env, "streaming"),
+        &500,
+        &(24 * HOUR),
+    );
+
+    // Distributing twice in a row must not pay out an empty balance.
+    assert_eq!(
+        client.try_distribute_royalties(&song_id).unwrap_err().unwrap(),
+        Error::ZeroAmount
+    );
+}
+
+#[test]
+fn distribute_royalty_accumulates_lifetime_total() {
+    let (env, client, artist) = setup();
+    let song_id = SdkString::from_str(&env, "s");
+    register(&client, &env, &artist, "s");
+
+    client.distribute_royalty(&song_id, &1_000);
+    client.distribute_royalty(&song_id, &500);
+
+    assert_eq!(client.get_song_info(&song_id).total_royalty_earned, 1_500);
+}
+
+#[test]
+fn rejects_unknown_song() {
+    let (env, client, _artist) = setup();
+    let missing = SdkString::from_str(&env, "nope");
+
+    assert_eq!(
+        client.try_distribute_royalty(&missing, &100).unwrap_err().unwrap(),
+        Error::SongNotFound
+    );
+    assert_eq!(
+        client.try_get_song_info(&missing).unwrap_err().unwrap(),
+        Error::SongNotFound
+    );
+}

--- a/contracts/music-royalty/src/types.rs
+++ b/contracts/music-royalty/src/types.rs
@@ -11,6 +11,31 @@ pub enum Error {
     Unauthorized = 5,
     InvalidAmount = 6,
     ZeroAmount = 7,
+    // ── Issue #1001 ──────────────────────────────────────────────────────────
+    // `InvalidSplits` was previously returned for every validation failure in
+    // the contract — a title that was too long, a license type that was too
+    // long, an out-of-range royalty rate, a bad licence duration. A caller who
+    // passed a perfectly good split table and an over-long title was told their
+    // splits were invalid, which is actively misleading.
+    //
+    // These variants are additive: existing codes 1-7 keep their meaning and
+    // their numbers, so nothing that decodes the old set breaks.
+    /// Song ID was empty or exceeded the maximum length.
+    InvalidSongId = 8,
+    /// Song title was empty or exceeded the maximum length.
+    InvalidTitle = 9,
+    /// License type string was empty or exceeded the maximum length.
+    InvalidLicenseType = 10,
+    /// Royalty rate was outside the permitted basis-point range.
+    InvalidRoyaltyRate = 11,
+    /// License duration was outside the permitted range.
+    InvalidDuration = 12,
+    /// The same account appeared more than once in a split table.
+    DuplicateSplitAccount = 13,
+    /// An accumulator would have overflowed its type.
+    Overflow = 14,
+    /// A license for this song and licensee does not exist.
+    LicenseNotFound = 15,
 }
 
 #[contracttype]


### PR DESCRIPTION
Closes #1001

## Error reporting — the biggest maintainability problem here

`Error::InvalidSplits` was returned for **every** validation failure in the contract: an over-long song ID, an over-long title, a bad license type, an out-of-range royalty rate, a bad license duration.

A caller who submitted a perfectly valid split table and a title one character too long was told **their splits were invalid**.

Split into specific variants:

| New | Replaces `InvalidSplits` for |
|---|---|
| `InvalidSongId` | empty / over-long song ID |
| `InvalidTitle` | empty / over-long title |
| `InvalidLicenseType` | empty / over-long license type |
| `InvalidRoyaltyRate` | rate outside the basis-point range |
| `InvalidDuration` | duration outside the permitted range |

Plus `LicenseNotFound` — `record_usage` and `get_license_info` reported `SongNotFound` when the song existed and only the *license* was missing, sending callers to look in the wrong place.

**All additive.** Codes 1–7 keep their meanings and their numbers, so anything decoding the existing set still works.

## Checked arithmetic

Every running total used unchecked `+=`. These are lifetime accumulators that only ever grow, and this crate's release profile sets `overflow-checks = true` — so a saturated total would **abort the invocation with no error code** rather than returning one.

Now `checked_add` with a new `Overflow` variant, across `total_royalty_earned`, `usage_count`, `total_paid`, `total_revenue`, `pending_distribution` and `distributed_revenue`.

`validate_splits` was the clearest case: it added to `total_share` **first** and range-checked **afterwards**, so a long enough table would overflow `u32` before the 10000 bound was ever tested. The comment there said *"Check for overflow"* — but it was checking the bound, which is a different thing.

`issue_license` computed `now + duration_seconds` unchecked. `MAX_LICENSE_DURATION` does bound it today, but relying on a validation elsewhere to prevent an arithmetic panic here is exactly the coupling that breaks when someone later raises the constant.

## Duplicate split accounts

A split table could list the same account **twice**. Both shares were paid to it while the artist believed it held one — and since the table still totalled 10000 with every share in range, nothing rejected it.

Now `DuplicateSplitAccount`. The O(n²) scan is affordable because shares must sum to 10000 and each is at least 1, which caps the table length.

Also reordered `validate_splits` to check emptiness **first**. It previously sat after the loop, where reading it required proving the loop body never ran to see that it was reachable at all.

## Tests

**The contract had none**, so this refactor had nothing holding it in place. Adds 19 covering the new error variants, duplicate rejection, split validation, licensing, expiry, usage accumulation and distribution.

`Cargo.toml` gains an `rlib` crate-type and the `testutils` dev-dependency — a cdylib-only crate can't be unit tested.

## Backwards compatibility

No function signature or storage layout changed. The one intentional behavioural change is *which* error code comes back for the misuses listed above — in every one of those cases the old code was wrong, so I'd argue reporting the accurate variant is the fix rather than a regression. Happy to keep `InvalidSplits` for any of them if you'd rather hold the codes fixed.

## Verification

Per the constraints I was working under I did **not** run `cargo test`, which matters more here than usual since I'm both refactoring and introducing the first test suite. The tests use `SdkString::from_str` aliased to avoid colliding with `soroban_sdk::String` in scope, and read state back through the generated client only. If the harness needs adjusting for your SDK pin, the fix is mechanical and I'll push it.
