### PR TITLE
test(interest-rate-model): comprehensive test suite + two real bugs found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2829,6 +2829,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-interest-rate-model"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "soroban-ledger-snapshot"
 version = "21.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tokio-util = { version = "0.7", features = ["io"] }
 
 [workspace]
 members = [
+    "contracts/interest-rate-model",
     "contracts/debugging-utils",
     "contracts/cross-contract-utils",
     "contracts/insurance-oracle",

--- a/contracts/interest-rate-model/src/lib.rs
+++ b/contracts/interest-rate-model/src/lib.rs
@@ -62,6 +62,10 @@ impl InterestRateModel {
     }
 
     pub fn set_tiered_rates(env: Env, admin: Address, tiers: Vec<RateTier>) {
+        let stored_admin = get_admin(&env).expect("Not initialized");
+        if admin != stored_admin {
+            panic!("Unauthorized: caller is not the admin");
+        }
         admin.require_auth();
         // basic validation
         let max = tiers.len();

--- a/contracts/interest-rate-model/src/storage.rs
+++ b/contracts/interest-rate-model/src/storage.rs
@@ -53,8 +53,8 @@ pub fn get_tier(env: &Env, index: u32) -> Option<RateTier> {
         .instance()
         .get(&key)
         .unwrap_or_else(|| Vec::new(env));
-    if (index as usize) < tiers.len() {
-        tiers.get(index as usize)
+    if index < tiers.len() {
+        tiers.get(index)
     } else {
         None
     }

--- a/contracts/interest-rate-model/src/test.rs
+++ b/contracts/interest-rate-model/src/test.rs
@@ -403,3 +403,35 @@ fn test_compute_rate_panics_before_init() {
     let (_, _, client) = setup();
     client.compute_rate(&500i128, &1000i128);
 }
+
+// ── Access control ────────────────────────────────────────────────────────────
+//
+// set_tiered_rates used to call `admin.require_auth()` on whatever address
+// was *passed in* as the `admin` parameter, without ever checking that
+// address against the contract's actual stored admin. Under
+// `mock_all_auths()` (used by every test's `setup()`), `require_auth()`
+// unconditionally succeeds for any address, so this was silently
+// unenforced: any caller could pass their own address as `admin` and set
+// the tiered rates. These tests exercise the fix — comparing the passed
+// `admin` against the stored admin — which holds regardless of auth
+// mocking, since it's a plain value check rather than a signature check.
+
+#[test]
+#[should_panic(expected = "Unauthorized")]
+fn test_set_tiered_rates_rejects_non_admin() {
+    let (env, admin, client) = setup();
+    client.initialize(&admin, &100u32, &1000u32, &5000u32, &CurveType::Linear);
+    let attacker = Address::generate(&env);
+    let tiers = vec![&env, RateTier { threshold_bps: 5000, rate_bps: 300 }];
+    client.set_tiered_rates(&attacker, &tiers);
+}
+
+#[test]
+#[should_panic]
+fn test_set_tiered_rates_panics_before_init() {
+    let (env, admin, client) = setup();
+    let tiers = vec![&env, RateTier { threshold_bps: 5000, rate_bps: 300 }];
+    // Not initialized yet — get_admin() returns None, so this must panic
+    // ("Not initialized"), not silently accept the tiers.
+    client.set_tiered_rates(&admin, &tiers);
+}


### PR DESCRIPTION
## Summary

Went to add the workspace member so this contract's tests actually run in CI — it wasn't in root `Cargo.toml`'s `[workspace] members` at all, and `cargo test` refused to even build it standalone (\"current package believes it's in a workspace when it's not\"). Once added, I immediately hit two real, pre-existing bugs that a real test run surfaces:

1. **`storage.rs`** — `get_tier()` compared `index as usize` against `tiers.len()` (Soroban's `Vec::len()` returns `u32`, not `usize`) and then called `tiers.get(index as usize)` against a `u32`-typed API — a compile error. **The crate has never actually compiled** since whatever `soroban-sdk` version made `Vec::len()` return `u32`. Fixed by comparing/indexing with `u32` directly (no cast needed).
2. **`lib.rs`** — `set_tiered_rates(env, admin: Address, tiers)` called `admin.require_auth()` on whatever address was *passed in*, without ever checking it against the contract's actual stored admin (`get_admin()`) — unlike every other admin-gated pattern in this codebase. Under `mock_all_auths()` (used by every test's `setup()`), `require_auth()` unconditionally succeeds for any address, so this was silently unenforced: **any caller could pass their own address as `admin` and set the tiered rates.** Fixed by comparing the passed `admin` against the stored admin before `require_auth()` — a plain value check, so it holds regardless of auth mocking.

Added `test_set_tiered_rates_rejects_non_admin` and `test_set_tiered_rates_panics_before_init`. I verified the first one actually catches bug #2 by stashing the `lib.rs` fix and rerunning just that test — it failed (\"did not panic as expected\"), confirming it's a real regression test — then restored the fix and reran the full suite.

## Test plan
Ran `cargo test -p soroban-interest-rate-model` for real — **all 36 tests pass** (34 pre-existing + 2 new).

Closes #994