### PR TITLE
enhancement(price-feed-adapter): robust error handling + fix non-compiling stub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,6 +2167,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "price_feed_adapter"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tokio-util = { version = "0.7", features = ["io"] }
 
 [workspace]
 members = [
+    "contracts/price_feed_adapter",
     "contracts/debugging-utils",
     "contracts/cross-contract-utils",
     "contracts/insurance-oracle",

--- a/contracts/price_feed_adapter/Cargo.toml
+++ b/contracts/price_feed_adapter/Cargo.toml
@@ -2,6 +2,24 @@
 name = "price_feed_adapter"
 version = "0.1.0"
 edition = "2021"
+description = "Price feed adapter contract with robust error handling for unsupported/empty symbols"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = "0.10.0"
+soroban-sdk = "21.0.6"
+
+[dev-dependencies]
+soroban-sdk = { version = "21.0.6", features = ["testutils"] }
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true

--- a/contracts/price_feed_adapter/src/lib.rs
+++ b/contracts/price_feed_adapter/src/lib.rs
@@ -1,32 +1,60 @@
-//! Dummy Price Feed Adapter contract with robust error handling
-use soroban_sdk::{contractimpl, Env, Symbol, Bytes, Error};
+//! Price Feed Adapter contract with robust error handling (#996).
+//!
+//! Was a "dummy" stub before this change: it targeted `soroban-sdk = "0.10.0"`
+//! (every sibling contract in this repo uses `21.0.6`), had no `#[contract]`
+//! attribute on the contract struct (required for `#[contractimpl]` to
+//! generate a valid contract), and its error type wrapped
+//! `soroban_sdk::Error` in a plain Rust enum that isn't a valid Soroban
+//! contract error type at all (`#[contracterror]`-derived `u32`-repr enums
+//! are the only kind the host ABI accepts as a function's `Result<T, E>`
+//! error). None of that compiled.
+#![no_std]
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+use soroban_sdk::{contract, contracterror, contractimpl, Bytes, Env};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
 pub enum PriceFeedError {
-    /// Returned when the requested symbol is not supported
-    UnsupportedSymbol,
-    /// Returned when the price data is unavailable
-    DataUnavailable,
-    /// Generic contract error wrapper
-    ContractError(Error),
+    /// `symbol` was empty.
+    EmptySymbol = 1,
+    /// `symbol` isn't one this adapter has a price for.
+    UnsupportedSymbol = 2,
 }
 
-impl From<Error> for PriceFeedError {
-    fn from(e: Error) -> Self { PriceFeedError::ContractError(e) }
-}
+/// Symbols this dummy adapter can price. A real adapter would look these up
+/// from configured feed sources instead of a fixed list.
+const SUPPORTED_SYMBOLS: [&[u8]; 3] = [b"XLM", b"USDC", b"BTC"];
 
+#[contract]
 pub struct PriceFeedAdapter;
 
 #[contractimpl]
 impl PriceFeedAdapter {
-    /// Returns a dummy price for `symbol`.
-    /// Errors if the symbol is empty or unsupported.
+    /// Returns a price for `symbol`, scaled to 6 decimals.
+    ///
+    /// # Errors
+    /// - [`PriceFeedError::EmptySymbol`] if `symbol` is empty.
+    /// - [`PriceFeedError::UnsupportedSymbol`] if `symbol` isn't recognised.
     pub fn get_price(env: Env, symbol: Bytes) -> Result<i128, PriceFeedError> {
         if symbol.is_empty() {
+            return Err(PriceFeedError::EmptySymbol);
+        }
+        if !Self::is_supported(env.clone(), symbol.clone()) {
             return Err(PriceFeedError::UnsupportedSymbol);
         }
-        // Dummy fixed price for illustration purposes
-        let price: i128 = 1_000_000; // e.g., price with 6 decimals
-        Ok(price)
+
+        // Dummy fixed price for illustration purposes (6 decimals).
+        Ok(1_000_000)
+    }
+
+    /// Whether `symbol` is one this adapter can price.
+    pub fn is_supported(env: Env, symbol: Bytes) -> bool {
+        SUPPORTED_SYMBOLS
+            .iter()
+            .any(|s| symbol == Bytes::from_slice(&env, s))
     }
 }
+
+#[cfg(test)]
+mod test;

--- a/contracts/price_feed_adapter/src/test.rs
+++ b/contracts/price_feed_adapter/src/test.rs
@@ -1,0 +1,46 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::Env;
+
+fn setup() -> (Env, PriceFeedAdapterClient<'static>) {
+    let env = Env::default();
+    let contract_id = env.register_contract(None, PriceFeedAdapter);
+    let client = PriceFeedAdapterClient::new(&env, &contract_id);
+    (env, client)
+}
+
+#[test]
+fn test_get_price_supported_symbols() {
+    let (env, client) = setup();
+    for sym in ["XLM", "USDC", "BTC"] {
+        let symbol = Bytes::from_slice(&env, sym.as_bytes());
+        assert_eq!(client.get_price(&symbol), 1_000_000);
+    }
+}
+
+#[test]
+fn test_get_price_empty_symbol_fails() {
+    let (env, client) = setup();
+    let symbol = Bytes::new(&env);
+    let result = client.try_get_price(&symbol);
+    assert_eq!(result, Err(Ok(PriceFeedError::EmptySymbol)));
+}
+
+#[test]
+fn test_get_price_unsupported_symbol_fails() {
+    let (env, client) = setup();
+    let symbol = Bytes::from_slice(&env, b"DOGE");
+    let result = client.try_get_price(&symbol);
+    assert_eq!(result, Err(Ok(PriceFeedError::UnsupportedSymbol)));
+}
+
+#[test]
+fn test_is_supported_matches_get_price() {
+    let (env, client) = setup();
+    let supported = Bytes::from_slice(&env, b"XLM");
+    let unsupported = Bytes::from_slice(&env, b"DOGE");
+
+    assert!(client.is_supported(&supported));
+    assert!(!client.is_supported(&unsupported));
+}


### PR DESCRIPTION
## Summary

This \"dummy\" contract has never actually built:
- `Cargo.toml` pinned `soroban-sdk = \"0.10.0\"` (every sibling contract in this repo uses `21.0.6` — an entirely different, incompatible API generation).
- The contract struct had no `#[contract]` attribute, which `#[contractimpl]` requires to generate a valid contract.
- `PriceFeedError` wrapped `soroban_sdk::Error` in a plain Rust enum, which isn't a valid Soroban contract error type at all — the host ABI only accepts `#[contracterror]`-derived, `#[repr(u32)]` enums as a function's `Result<T, E>` error.
- It also wasn't a member of the workspace, so none of this was ever caught by a build.

Rebuilt to match every other contract's established convention:
- `soroban-sdk 21.0.6`, `#[contract]` struct, `#[contracterror]` enum (`EmptySymbol`, `UnsupportedSymbol`).
- `get_price` validates both the empty-symbol and unsupported-symbol cases before returning its (still dummy/fixed) price.
- Added `is_supported()` and a small fixed symbol list (XLM/USDC/BTC) so \"unsupported\" is actually checkable instead of always succeeding once past the empty check.
- Added `contracts/price_feed_adapter/src/test.rs`: supported symbols price correctly, empty symbol and unsupported symbol both return their specific error, `is_supported` agrees with `get_price`.

## Test plan
Ran `cargo test -p price_feed_adapter` for real — **all 4 tests pass**.

Closes #996