### PR TITLE
test(governance): add coverage for delegation resolution edge cases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2822,6 +2822,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "soroban-governance"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk",
+]
+
+[[package]]
 name = "soroban-insurance-protocol"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tokio-util = { version = "0.7", features = ["io"] }
 
 [workspace]
 members = [
+    "contracts/governance",
     "contracts/debugging-utils",
     "contracts/cross-contract-utils",
     "contracts/insurance-oracle",

--- a/contracts/governance/src/test.rs
+++ b/contracts/governance/src/test.rs
@@ -583,3 +583,79 @@ fn test_full_proposal_lifecycle() {
     client.execute(&proposer, &id);
     assert_eq!(client.get_proposal(&id).status, ProposalStatus::Executed);
 }
+
+// ── Delegation — resolution edge cases ─────────────────────────────────────────
+//
+// test_delegation_transfers_vote above only has the *delegate* call vote()
+// with their own balance — it never actually exercises resolve_delegate's
+// redirect (a *delegator* calling vote() themselves), its multi-hop chain
+// walk, or its cycle handling, despite the module doc explicitly advertising
+// "Recursive delegation (up to depth 8)" as a supported feature.
+
+#[test]
+fn test_vote_via_delegator_uses_delegates_balance() {
+    let (env, admin, client) = setup();
+    let delegator = Address::generate(&env);
+    let delegate = Address::generate(&env);
+    client.mint(&admin, &delegator, &1_000_000);
+    client.mint(&admin, &delegate, &300_000);
+    client.delegate(&delegator, &Some(delegate.clone()));
+
+    let id = client.propose(
+        &delegator,
+        &String::from_str(&env, "title"),
+        &String::from_str(&env, "desc"),
+        &0,
+    );
+
+    // The delegator calls vote() directly (not the delegate). resolve_delegate
+    // redirects to `delegate`, so the vote is cast with the delegate's own
+    // balance (300_000), not the delegator's (1_000_000) — delegation moves
+    // *who* can cast the vote, it doesn't pool balances together.
+    client.vote(&delegator, &id, &VoteChoice::For);
+    let p = client.get_proposal(&id);
+    assert_eq!(p.votes_for, 300_000);
+
+    // The vote is recorded against the resolved delegate, so the delegate
+    // themselves is now blocked from voting again on this proposal too.
+    let result = client.try_vote(&delegate, &id, &VoteChoice::Against);
+    assert_eq!(result, Err(Ok(Error::AlreadyVoted)));
+}
+
+#[test]
+fn test_delegation_chain_resolves_through_multiple_hops() {
+    let (env, admin, client) = setup();
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+    client.mint(&admin, &a, &100);
+    client.mint(&admin, &c, &900);
+
+    // a -> b -> c: resolving from `a` must walk both hops to reach `c`.
+    client.delegate(&a, &Some(b.clone()));
+    client.delegate(&b, &Some(c.clone()));
+
+    assert_eq!(client.get_delegate(&a), c);
+    assert_eq!(client.get_voting_power(&a), 100); // own balance, unaffected by delegating out
+}
+
+#[test]
+fn test_delegation_cycle_resolves_without_panicking() {
+    // Mutual delegation (a -> b -> a) must not infinite-loop or panic;
+    // resolve_delegate is bounded to 8 iterations specifically so a cycle
+    // like this terminates deterministically instead of hanging.
+    let (env, admin, client) = setup();
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    client.mint(&admin, &a, &100);
+    client.mint(&admin, &b, &200);
+
+    client.delegate(&a, &Some(b.clone()));
+    client.delegate(&b, &Some(a.clone()));
+
+    // Must resolve to *some* address in the cycle without panicking, and
+    // resolving repeatedly must be stable (same input state, same output).
+    let resolved_first = client.get_delegate(&a);
+    assert!(resolved_first == a || resolved_first == b);
+    assert_eq!(client.get_delegate(&a), resolved_first);
+}


### PR DESCRIPTION
## Summary

Added `governance` to the workspace so its tests actually run in CI (it wasn't a member — `cargo test` refused to build it standalone). Unlike the other three contracts I've worked on in this batch, this one **compiled cleanly and all 42 existing tests passed immediately** — it's already thoroughly tested.

So instead of padding the suite with redundant tests, I reviewed `lib.rs`/`storage.rs` for a genuine gap. Found one: the module doc advertises \"Recursive delegation (up to depth 8)\" and `resolve_delegate()` implements a bounded chain walk, but `test_delegation_transfers_vote` (the only existing delegation+voting test) has the *delegate* call `vote()` with their own balance — it never actually exercises `resolve_delegate`'s redirect path (a *delegator* calling `vote()` themselves), a multi-hop chain, or a cycle.

Added:
- **`test_vote_via_delegator_uses_delegates_balance`** — the delegator calls `vote()` directly; confirms it's redirected to the delegate's own balance (not pooled with the delegator's), and that the vote is recorded against the delegate (so the delegate is now blocked from voting again too).
- **`test_delegation_chain_resolves_through_multiple_hops`** — `a -> b -> c`, confirms resolving from `a` walks both hops to reach `c`.
- **`test_delegation_cycle_resolves_without_panicking`** — mutual delegation (`a -> b -> a`) terminates deterministically via the 8-iteration bound instead of hanging or panicking, and resolves stably across repeated calls.

## Test plan
Ran `cargo test -p soroban-governance` for real — **all 45 tests pass** (42 pre-existing + 3 new).

Closes #997