### PR TITLE
fixed token balance uiissue

### DIFF
--- a/frontend/src/app/nft-amm/page.tsx
+++ b/frontend/src/app/nft-amm/page.tsx
@@ -210,6 +210,38 @@ function StatCard({
   );
 }
 
+// ── Token Balance Display ─────────────────────────────────────────────────────
+
+interface TokenBalanceDisplayProps {
+  balance: number;
+  spotPrice: number;
+  poolType: PoolType;
+}
+
+const TokenBalanceDisplay = React.memo(({ balance, spotPrice, poolType }: TokenBalanceDisplayProps) => {
+  const isInsufficient = (poolType === "Buy" || poolType === "Trade") && balance < spotPrice;
+  const formattedBalance = (balance / 10_000_000).toFixed(2); // conversion to XLM
+
+  return (
+    <div>
+      <p className="text-xs text-gray-500 flex items-center gap-1">
+        Token Balance
+        {isInsufficient && (
+          <span 
+            className="inline-block h-1.5 w-1.5 rounded-full bg-red-500 animate-pulse" 
+            title="Insufficient balance for spot trade" 
+          />
+        )}
+      </p>
+      <p className={`mt-0.5 font-medium ${isInsufficient ? "text-red-400 font-semibold" : "text-gray-300"}`}>
+        {formattedBalance} XLM
+      </p>
+    </div>
+  );
+});
+
+TokenBalanceDisplay.displayName = "TokenBalanceDisplay";
+
 // ── Pool Card ─────────────────────────────────────────────────────────────────
 
 function PoolCard({

--- a/frontend/src/app/nft-amm/page.tsx
+++ b/frontend/src/app/nft-amm/page.tsx
@@ -356,12 +356,11 @@ function PoolCard({
               <p className="text-xs text-gray-500">NFTs in Pool</p>
               <p className="mt-0.5 text-gray-300">{pool.nftCount}</p>
             </div>
-            <div>
-              <p className="text-xs text-gray-500">Token Balance</p>
-              <p className="mt-0.5 text-gray-300">
-                {stroopsToXlm(pool.tokenBalance)} XLM
-              </p>
-            </div>
+            <TokenBalanceDisplay
+              balance={pool.tokenBalance}
+              spotPrice={pool.spotPrice}
+              poolType={pool.poolType}
+            />
             <div>
               <p className="text-xs text-gray-500">Total Volume</p>
               <p className="mt-0.5 text-gray-300">


### PR DESCRIPTION
closes #926 

## Summary
This PR addresses the token balance display issue on the NFT AMM page (#926). It introduces a new, memoized `TokenBalanceDisplay` component that provides clearer visibility into the user's XLM balance relative to the current spot price.

## Changes
- **New Component**: Added `TokenBalanceDisplay` in `frontend/src/app/nft-amm/page.tsx`.
- **Logic**:
  - Calculates the balance in XLM by dividing the raw value by 10,000,000 and formatting to 2 decimal places.
  - Detects insufficient balance when the user's balance is lower than the spot price for "Buy" or "Trade" pool types.
- **Visual Feedback**:
  - Displays a pulsing red indicator dot when funds are insufficient.
  - Changes the text color to red and makes it bold when the balance is insufficient; otherwise, it remains gray.
  - Uses `React.memo` for performance optimization.

## How to Test
1. Navigate to the NFT AMM page.
2. Select a "Buy" or "Trade" pool type.
3. Observe the "Token Balance" section:
   - If your balance is lower than the spot price, you should see a red dot and the balance text should turn red/bold.
   - If your balance is sufficient, the text should be gray with no indicator.
