### PR TITLE
feat: enhance Network Selector error handling (fixes #927)

### DIFF
--- a/frontend/src/__tests__/components/NetworkSwitcher.test.tsx
+++ b/frontend/src/__tests__/components/NetworkSwitcher.test.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import NetworkSwitcher, { NETWORKS } from '../../components/NetworkSwitcher';
+
+let mockTime = 0;
+
+beforeAll(() => {
+  jest.spyOn(performance, 'now').mockImplementation(() => {
+    mockTime += 100;
+    return mockTime;
+  });
+});
+
+beforeEach(() => {
+  mockTime = 0;
+});
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+describe('NetworkSwitcher', () => {
+  beforeEach(() => {
+    // Reset fetch mock before each test
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ result: { status: 'healthy' } }),
+      })
+    ) as jest.Mock;
+
+    // Clear local storage
+    localStorage.clear();
+  });
+
+  it('renders default network and ping endpoints on mount', async () => {
+    render(<NetworkSwitcher />);
+    
+    // Check if default network (Testnet) is rendered
+    expect(screen.getByText('Testnet')).toBeInTheDocument();
+
+    // Check if all networks are pinged (Checking... state first)
+    // Wait for the checking state to resolve and the latency to be displayed
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledTimes(Object.keys(NETWORKS).length);
+    });
+
+    // Check if latency is rendered
+    const msTexts = await screen.findAllByText(/\d+ms/);
+    expect(msTexts.length).toBeGreaterThan(0);
+  });
+
+  it('displays Timeout when fetch aborts', async () => {
+    // Mock fetch to simulate AbortError (Timeout)
+    const abortError = new Error('The user aborted a request.');
+    abortError.name = 'AbortError';
+    global.fetch = jest.fn(() => Promise.reject(abortError)) as jest.Mock;
+
+    render(<NetworkSwitcher />);
+
+    // Open dropdown
+    fireEvent.click(screen.getByRole('button', { name: 'Select Network' }));
+
+    await waitFor(() => {
+      const offlineTexts = screen.getAllByText('Offline');
+      expect(offlineTexts.length).toBeGreaterThan(0);
+      const timeoutTexts = screen.getAllByText('Timeout');
+      expect(timeoutTexts.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('displays HTTP status when response is not ok', async () => {
+    // Mock fetch to simulate HTTP 503 error
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: false,
+        status: 503,
+      })
+    ) as jest.Mock;
+
+    render(<NetworkSwitcher />);
+
+    // Open dropdown
+    fireEvent.click(screen.getByRole('button', { name: 'Select Network' }));
+
+    await waitFor(() => {
+      const offlineTexts = screen.getAllByText('Offline');
+      expect(offlineTexts.length).toBeGreaterThan(0);
+      const httpTexts = screen.getAllByText('HTTP 503');
+      expect(httpTexts.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('displays Unhealthy response when status is not healthy', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ result: null }),
+      })
+    ) as jest.Mock;
+
+    render(<NetworkSwitcher />);
+
+    // Open dropdown
+    fireEvent.click(screen.getByRole('button', { name: 'Select Network' }));
+
+    await waitFor(() => {
+      const offlineTexts = screen.getAllByText('Offline');
+      expect(offlineTexts.length).toBeGreaterThan(0);
+      const errorTexts = screen.getAllByText('Unhealthy response');
+      expect(errorTexts.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('displays generic Network Error on throw', async () => {
+    global.fetch = jest.fn(() => Promise.reject(new Error('Failed to fetch'))) as jest.Mock;
+
+    render(<NetworkSwitcher />);
+
+    // Open dropdown
+    fireEvent.click(screen.getByRole('button', { name: 'Select Network' }));
+
+    await waitFor(() => {
+      const offlineTexts = screen.getAllByText('Offline');
+      expect(offlineTexts.length).toBeGreaterThan(0);
+      const errTexts = screen.getAllByText('Failed to fetch');
+      expect(errTexts.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('can switch networks', async () => {
+    render(<NetworkSwitcher />);
+
+    // Open dropdown
+    fireEvent.click(screen.getByRole('button', { name: 'Select Network' }));
+
+    // Click Mainnet
+    fireEvent.click(screen.getByText('Mainnet'));
+
+    // Check if Mainnet is selected
+    await waitFor(() => {
+      expect(localStorage.getItem('soroban_playground_network')).toBe('mainnet');
+    });
+  });
+});

--- a/frontend/src/components/NetworkSwitcher.tsx
+++ b/frontend/src/components/NetworkSwitcher.tsx
@@ -43,6 +43,7 @@ export interface NetworkHealth {
   status: "healthy" | "degraded" | "offline" | "checking";
   latencyMs: number | null;
   lastChecked: number | null;
+  error?: string;
 }
 
 export default function NetworkSwitcher() {
@@ -101,18 +102,26 @@ export default function NetworkSwitcher() {
 
         setHealthMap((prev) => ({
           ...prev,
-          [netId]: { status, latencyMs: latency, lastChecked: Date.now() },
+          [netId]: { status, latencyMs: latency, lastChecked: Date.now(), error: !isHealthy ? "Unhealthy response" : undefined },
         }));
       } else {
         setHealthMap((prev) => ({
           ...prev,
-          [netId]: { status: "offline", latencyMs: latency, lastChecked: Date.now() },
+          [netId]: { status: "offline", latencyMs: latency, lastChecked: Date.now(), error: `HTTP ${res.status}` },
         }));
       }
-    } catch {
+    } catch (err) {
+      let errorMessage = "Network Error";
+      if (err instanceof Error) {
+        if (err.name === "AbortError") {
+          errorMessage = "Timeout";
+        } else {
+          errorMessage = err.message;
+        }
+      }
       setHealthMap((prev) => ({
         ...prev,
-        [netId]: { status: "offline", latencyMs: null, lastChecked: Date.now() },
+        [netId]: { status: "offline", latencyMs: null, lastChecked: Date.now(), error: errorMessage },
       }));
     }
   }, []);
@@ -242,13 +251,26 @@ export default function NetworkSwitcher() {
                     </div>
                   </div>
 
-                  <div className="text-right shrink-0 ml-2">
-                    {health.latencyMs !== null ? (
-                      <span className="font-mono text-[10px] text-teal-300 font-medium">
+                  <div className="text-right shrink-0 ml-2 flex flex-col items-end justify-center">
+                    {health.status === "checking" ? (
+                      <span className="font-mono text-[10px] text-slate-400 font-medium animate-pulse">
+                        Checking...
+                      </span>
+                    ) : health.status === "offline" ? (
+                      <div className="flex flex-col items-end">
+                        <span className="text-[10px] text-rose-400 font-medium">Offline</span>
+                        {health.error && (
+                          <span className="text-[9px] text-rose-400/80 max-w-[90px] truncate" title={health.error}>
+                            {health.error}
+                          </span>
+                        )}
+                      </div>
+                    ) : health.latencyMs !== null ? (
+                      <span className={`font-mono text-[10px] font-medium ${health.status === "degraded" ? "text-amber-400" : "text-teal-300"}`}>
                         {health.latencyMs}ms
                       </span>
                     ) : (
-                      <span className="text-[10px] text-rose-400">Offline</span>
+                      <span className="text-[10px] text-slate-500">--</span>
                     )}
                   </div>
                 </button>


### PR DESCRIPTION
This PR implements the enhancements requested in #927.

### Changes
- **Specific Error Capture:** Updated `checkNetworkLatency` in `NetworkSwitcher.tsx` to handle `AbortError` (Timeout), HTTP status errors (e.g., `HTTP 503`), and generic network errors.
- **Extended Health Interface:** Added an `error` field to `NetworkHealth` to store these failure reasons.
- **UI Enhancements:** The network item now displays a `Checking...` pulse state while the ping is in progress. If offline, the specific error text is displayed below the `Offline` badge.
- **Testing Infrastructure:** Added a new comprehensive test suite in `NetworkSwitcher.test.tsx` that verifies state transitions and UI rendering for all networking failure edge cases.

### Verification
Tests pass locally, confirming correct error boundary behaviors. Ensure back-compat with the original `localStorage` key (`soroban_playground_network`) and `NETWORKS` default layout.