### PR TITLE
feat(verification): add Soroban source and bytecode verification

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -29,6 +29,13 @@ WASM_TARGET_SUBPATH=target/wasm32-unknown-unknown/release
 WASM_FILENAME=soroban_contract.wasm
 SOROBAN_SDK_VERSION=20.0.0
 
+# Contract source verification
+VERIFICATION_MAX_SOURCE_BYTES=1048576
+VERIFICATION_MAX_WASM_BYTES=20971520
+VERIFICATION_ARTIFACT_ROOT=
+# Optional per-network RPC override, e.g. TESTNET_RPC_URL=https://soroban-testnet.stellar.org
+TESTNET_RPC_URL=
+
 # Network defaults
 DEFAULT_NETWORK=testnet
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -30,6 +30,12 @@
   - `400` when dependency payload cannot be safely transformed into `Cargo.toml`.
   - `500` on compilation failures (stderr/diagnostics included).
 
+## Contract Source Verification
+
+The backend exposes `POST /api/verify/contracts` to compile submitted Soroban Rust source and compare the SHA-256 hash of the exact resulting WASM bytes with the deployed contract WASM retrieved through Soroban RPC. It also supports `GET /api/verify/contracts/:id`, `GET /api/verify/contracts/:id/source`, `POST /api/verify/contracts/:id/reverify`, and `GET /api/verify/contracts/search`.
+
+Use `wasmBase64` or `wasmPath` when a caller already has the compiled artifact. Status and search responses intentionally omit source code; see [`src/docs/verification.md`](src/docs/verification.md) for request examples, configuration, and the meaning of each hash.
+
 ## Cache Administration
 
 The backend now includes a multi-level compile cache with:

--- a/backend/migrations/V007__contract_verification.down.sql
+++ b/backend/migrations/V007__contract_verification.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS idx_contract_verification_contract;
+DROP INDEX IF EXISTS idx_contract_verification_status;
+DROP TABLE IF EXISTS contract_verification;

--- a/backend/migrations/V007__contract_verification.up.sql
+++ b/backend/migrations/V007__contract_verification.up.sql
@@ -1,0 +1,23 @@
+-- Contract source and bytecode verification records.
+CREATE TABLE IF NOT EXISTS contract_verification (
+    id TEXT PRIMARY KEY,
+    contract_id TEXT NOT NULL,
+    network TEXT NOT NULL,
+    source_code TEXT NOT NULL,
+    source_hash TEXT NOT NULL,
+    dependencies TEXT NOT NULL DEFAULT '{}',
+    metadata TEXT NOT NULL DEFAULT '{}',
+    wasm_hash TEXT,
+    on_chain_wasm_hash TEXT,
+    status TEXT NOT NULL CHECK (status IN ('pending', 'verified', 'mismatch', 'failed')),
+    error_code TEXT,
+    error_message TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    verified_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_contract_verification_contract
+    ON contract_verification (contract_id, network, updated_at);
+CREATE INDEX IF NOT EXISTS idx_contract_verification_status
+    ON contract_verification (status, updated_at);

--- a/backend/src/docs/swagger.js
+++ b/backend/src/docs/swagger.js
@@ -40,6 +40,11 @@ const options = {
         description: 'Contract deployment and invocation operations',
       },
       {
+        name: 'Contract Verification',
+        description:
+          'Source-to-WASM hash verification for deployed Soroban contracts',
+      },
+      {
         name: 'RPC Network Manager',
         description: 'Circuit breaker & RPC health status',
       },
@@ -54,6 +59,14 @@ const options = {
           type: 'http',
           scheme: 'bearer',
           bearerFormat: 'JWT',
+        },
+      },
+      parameters: {
+        VerificationId: {
+          in: 'path',
+          name: 'id',
+          required: true,
+          schema: { type: 'string' },
         },
       },
       schemas: {
@@ -87,6 +100,51 @@ const options = {
             },
             status: { type: 'string', example: 'queued' },
             createdAt: { type: 'string', format: 'date-time' },
+          },
+        },
+        VerificationRequest: {
+          type: 'object',
+          required: ['contractId', 'sourceCode'],
+          properties: {
+            contractId: {
+              type: 'string',
+              description: 'Stellar Soroban contract ID',
+            },
+            network: { type: 'string', default: 'testnet' },
+            sourceCode: {
+              type: 'string',
+              description: 'Rust source for src/lib.rs',
+            },
+            dependencies: {
+              type: 'object',
+              additionalProperties: { type: 'string' },
+            },
+            metadata: { type: 'object' },
+            wasmBase64: {
+              type: 'string',
+              description: 'Optional compiled WASM artifact',
+            },
+            wasmPath: {
+              type: 'string',
+              description:
+                'Optional artifact path inside VERIFICATION_ARTIFACT_ROOT',
+            },
+          },
+        },
+        VerificationRecord: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            contractId: { type: 'string' },
+            network: { type: 'string' },
+            sourceHash: { type: 'string' },
+            wasmHash: { type: 'string', nullable: true },
+            onChainWasmHash: { type: 'string', nullable: true },
+            status: {
+              type: 'string',
+              enum: ['pending', 'verified', 'mismatch', 'failed'],
+            },
+            verified: { type: 'boolean' },
           },
         },
         CompileJobStatus: {

--- a/backend/src/docs/verification.doc.js
+++ b/backend/src/docs/verification.doc.js
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 StellarDevTools
+// SPDX-License-Identifier: MIT
+
+/**
+ * @openapi
+ * /api/verify/contracts:
+ *   post:
+ *     summary: Verify Soroban contract source
+ *     description: Compiles the submitted Rust source (or accepts a bounded WASM artifact), hashes the exact bytes with SHA-256, and compares them with the deployed Soroban contract WASM.
+ *     tags: [Contract Verification]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/VerificationRequest'
+ *     responses:
+ *       200:
+ *         description: Source compiled to the exact deployed WASM bytes
+ *       202:
+ *         description: Verification completed with a mismatch
+ *       400:
+ *         description: Invalid request
+ *       422:
+ *         description: Source compilation failed
+ *       502:
+ *         description: Soroban RPC lookup failed
+ *
+ * /api/verify/contracts/{id}:
+ *   get:
+ *     summary: Get verification status
+ *     tags: [Contract Verification]
+ *     parameters:
+ *       - $ref: '#/components/parameters/VerificationId'
+ *     responses:
+ *       200:
+ *         description: Verification status without source code
+ *       404:
+ *         description: Verification record not found
+ *
+ * /api/verify/contracts/{id}/source:
+ *   get:
+ *     summary: Get verified source record
+ *     tags: [Contract Verification]
+ *     parameters:
+ *       - $ref: '#/components/parameters/VerificationId'
+ *     responses:
+ *       200:
+ *         description: Stored source code and its source hash
+ *
+ * /api/verify/contracts/{id}/reverify:
+ *   post:
+ *     summary: Re-verify an existing source record
+ *     tags: [Contract Verification]
+ *     parameters:
+ *       - $ref: '#/components/parameters/VerificationId'
+ *     responses:
+ *       200:
+ *         description: Source matches the deployed WASM
+ *       202:
+ *         description: Verification completed with a mismatch
+ *
+ * /api/verify/contracts/search:
+ *   get:
+ *     summary: Search verification records
+ *     tags: [Contract Verification]
+ *     parameters:
+ *       - in: query
+ *         name: contractId
+ *         schema: { type: string }
+ *       - in: query
+ *         name: network
+ *         schema: { type: string }
+ *       - in: query
+ *         name: status
+ *         schema: { type: string, enum: [pending, verified, mismatch, failed] }
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer, default: 20, maximum: 100 }
+ *       - in: query
+ *         name: offset
+ *         schema: { type: integer, default: 0, minimum: 0 }
+ *     responses:
+ *       200:
+ *         description: Matching verification records without source code
+ */
+const verificationDocs = {};
+export default verificationDocs;

--- a/backend/src/docs/verification.md
+++ b/backend/src/docs/verification.md
@@ -1,0 +1,34 @@
+# Contract Source Verification
+
+The verification service checks whether submitted Rust source produces the exact WASM bytes currently deployed for a Soroban contract.
+
+## API
+
+- `POST /api/verify/contracts` submits source for verification.
+- `GET /api/verify/contracts/:id` returns status and hashes, without source code.
+- `GET /api/verify/contracts/:id/source` returns the stored source record after a successful match.
+- `POST /api/verify/contracts/:id/reverify` repeats verification against the current on-chain WASM.
+- `GET /api/verify/contracts/search` filters records by `contractId`, `network`, and `status`.
+
+A submission must include `contractId` and `sourceCode`. `contractId` is validated as a checksummed Stellar contract address. `sourceCode` is the contents of the crate's `src/lib.rs` used by the existing compiler. `dependencies` are passed through the same sanitized Cargo dependency flow as `/api/compile`.
+
+For already-built artifacts, callers can supply either `wasmBase64` or `wasmPath`. Paths must remain inside `VERIFICATION_ARTIFACT_ROOT` (which defaults to the backend working directory). Base64 and file artifacts are bounded by `VERIFICATION_MAX_WASM_BYTES`.
+
+## Hashes and status
+
+- `sourceHash`: SHA-256 of the submitted UTF-8 source text.
+- `wasmHash`: SHA-256 of the exact bytes produced by Cargo or supplied by the caller.
+- `onChainWasmHash`: SHA-256 of the exact WASM retrieved from Soroban RPC.
+- `verified`: true only when `wasmHash` and `onChainWasmHash` are equal.
+
+A mismatch is a completed verification with status `mismatch`; it is not treated as a transport or server error. Compilation and RPC failures are stored as `failed` records with a machine-readable error code.
+
+## Configuration
+
+- `SOROBAN_RPC_URL` sets the default Soroban RPC endpoint.
+- `<NETWORK>_RPC_URL` overrides the endpoint for a named network, for example `TESTNET_RPC_URL`.
+- `VERIFICATION_ARTIFACT_ROOT` limits accepted local WASM paths.
+- `VERIFICATION_MAX_SOURCE_BYTES` defaults to 1 MiB.
+- `VERIFICATION_MAX_WASM_BYTES` defaults to 20 MiB.
+
+The storage table is created by migration `V007__contract_verification` and is also initialized lazily for compatibility with deployments that do not run migrations during startup.

--- a/backend/src/routes/api.js
+++ b/backend/src/routes/api.js
@@ -17,6 +17,7 @@ import eventsRouter from './events.js';
 import patentsRouter from './patents.js';
 import tokenBurnRouter from './tokenBurn.js';
 import oracleRouter from './oracle.js';
+import verificationRouter from './verification.js';
 import {
   versionTransformer,
   requestTransformerV2,
@@ -102,6 +103,7 @@ router.use((req, res, next) => {
   return next();
 });
 router.use('/oracle', oracleRouter);
+router.use('/verify', verificationRouter);
 
 // Default to v1 for backward compatibility, while allowing headers such as:
 // Accept: application/vnd.soroban-playground.v2+json

--- a/backend/src/routes/verification.js
+++ b/backend/src/routes/verification.js
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 StellarDevTools
+// SPDX-License-Identifier: MIT
+
+import express from 'express';
+import { asyncHandler } from '../middleware/errorHandler.js';
+import { rateLimitMiddleware } from '../middleware/rateLimiter.js';
+import verifyService from '../services/verifyService.js';
+
+const router = express.Router();
+
+router.post(
+  '/contracts',
+  rateLimitMiddleware('global'),
+  asyncHandler(async (req, res) => {
+    const result = await verifyService.submitVerification(req.body || {});
+    return res.status(result.status === 'verified' ? 200 : 202).json({
+      success: result.verified,
+      data: result,
+    });
+  })
+);
+
+router.get(
+  '/contracts/search',
+  asyncHandler(async (req, res) => {
+    const result = await verifyService.searchVerifications(req.query || {});
+    return res.json({ success: true, data: result });
+  })
+);
+
+router.get(
+  '/contracts/:id/source',
+  asyncHandler(async (req, res) => {
+    const result = await verifyService.getSource(req.params.id);
+    return res.json({ success: true, data: result });
+  })
+);
+
+router.post(
+  '/contracts/:id/reverify',
+  rateLimitMiddleware('global'),
+  asyncHandler(async (req, res) => {
+    const result = await verifyService.reverifyContract(
+      req.params.id,
+      req.body || {}
+    );
+    return res.status(result.status === 'verified' ? 200 : 202).json({
+      success: result.verified,
+      data: result,
+    });
+  })
+);
+
+router.get(
+  '/contracts/:id',
+  asyncHandler(async (req, res) => {
+    const result = await verifyService.getVerification(req.params.id);
+    return res.json({ success: true, data: result });
+  })
+);
+
+export default router;

--- a/backend/src/services/verifyService.js
+++ b/backend/src/services/verifyService.js
@@ -1,0 +1,692 @@
+// Copyright (c) 2026 StellarDevTools
+// SPDX-License-Identifier: MIT
+
+import crypto from 'crypto';
+import fs from 'fs/promises';
+import path from 'path';
+import { SorobanRpc, StrKey } from '@stellar/stellar-sdk';
+import DatabaseService from './databaseService.js';
+import { compileQueued } from './compileService.js';
+import { sanitizeDependenciesInput } from '../routes/compile_utils.js';
+
+const CONTRACT_ID_REGEX = /^C[A-Z0-9]{55}$/;
+const HASH_REGEX = /^[a-f0-9]{64}$/i;
+const DEFAULT_MAX_SOURCE_BYTES = 1024 * 1024;
+const DEFAULT_MAX_WASM_BYTES = 20 * 1024 * 1024;
+const DEFAULT_NETWORK = 'testnet';
+const DEFAULT_RPC_URL = 'https://soroban-testnet.stellar.org';
+const TABLE_NAME = 'contract_verification';
+
+const CREATE_TABLE_SQL = `
+  CREATE TABLE IF NOT EXISTS ${TABLE_NAME} (
+    id TEXT PRIMARY KEY,
+    contract_id TEXT NOT NULL,
+    network TEXT NOT NULL,
+    source_code TEXT NOT NULL,
+    source_hash TEXT NOT NULL,
+    dependencies TEXT NOT NULL DEFAULT '{}',
+    metadata TEXT NOT NULL DEFAULT '{}',
+    wasm_hash TEXT,
+    on_chain_wasm_hash TEXT,
+    status TEXT NOT NULL,
+    error_code TEXT,
+    error_message TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    verified_at TEXT
+  )
+`;
+
+export class VerificationError extends Error {
+  constructor(statusCode, code, message, details) {
+    super(message);
+    this.name = 'VerificationError';
+    this.statusCode = statusCode;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function clone(value) {
+  return value === undefined ? value : JSON.parse(JSON.stringify(value));
+}
+
+function parseJson(value, fallback) {
+  if (value === undefined || value === null || value === '') return fallback;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
+}
+
+function validatePlainObject(value, field) {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new VerificationError(
+      400,
+      'INVALID_INPUT',
+      `${field} must be a plain object`
+    );
+  }
+}
+
+export function validateContractId(contractId) {
+  if (typeof contractId !== 'string' || !CONTRACT_ID_REGEX.test(contractId)) {
+    throw new VerificationError(
+      400,
+      'INVALID_CONTRACT_ID',
+      'contractId must be a valid Stellar contract ID'
+    );
+  }
+  try {
+    StrKey.decodeContract(contractId);
+  } catch {
+    throw new VerificationError(
+      400,
+      'INVALID_CONTRACT_ID',
+      'contractId must contain a valid Stellar contract address checksum'
+    );
+  }
+  return contractId;
+}
+
+export function normalizeHash(hash, field = 'hash') {
+  if (typeof hash !== 'string' || !HASH_REGEX.test(hash)) {
+    throw new VerificationError(
+      400,
+      'INVALID_HASH',
+      `${field} must be a 64-character hexadecimal SHA-256 hash`
+    );
+  }
+  return hash.toLowerCase();
+}
+
+export function hashWasm(wasm) {
+  if (!Buffer.isBuffer(wasm) && !(wasm instanceof Uint8Array)) {
+    throw new VerificationError(
+      400,
+      'INVALID_WASM',
+      'WASM must be a Buffer or Uint8Array'
+    );
+  }
+  return crypto.createHash('sha256').update(wasm).digest('hex');
+}
+
+export function hashSource(sourceCode) {
+  return crypto.createHash('sha256').update(sourceCode, 'utf8').digest('hex');
+}
+
+function validateSource(sourceCode, maxSourceBytes) {
+  if (typeof sourceCode !== 'string' || sourceCode.trim().length === 0) {
+    throw new VerificationError(
+      400,
+      'INVALID_SOURCE',
+      'sourceCode is required and must not be empty'
+    );
+  }
+
+  const sourceBytes = Buffer.byteLength(sourceCode, 'utf8');
+  if (sourceBytes > maxSourceBytes) {
+    throw new VerificationError(
+      413,
+      'SOURCE_TOO_LARGE',
+      `sourceCode exceeds the ${maxSourceBytes} byte limit`,
+      { maxSourceBytes, actualBytes: sourceBytes }
+    );
+  }
+}
+
+function validateWasmSize(wasm, maxWasmBytes) {
+  if (!Buffer.isBuffer(wasm) && !(wasm instanceof Uint8Array)) {
+    throw new VerificationError(
+      502,
+      'INVALID_WASM_RESPONSE',
+      'Soroban RPC returned an invalid WASM value'
+    );
+  }
+  if (wasm.length === 0) {
+    throw new VerificationError(400, 'INVALID_WASM', 'WASM must not be empty');
+  }
+  const wasmHeader = Buffer.from(wasm).subarray(0, 8);
+  if (!wasmHeader.equals(Buffer.from([0, 97, 115, 109, 1, 0, 0, 0]))) {
+    throw new VerificationError(
+      400,
+      'INVALID_WASM',
+      'WASM must use the standard WebAssembly binary header'
+    );
+  }
+  if (wasm.length > maxWasmBytes) {
+    throw new VerificationError(
+      413,
+      'WASM_TOO_LARGE',
+      `WASM exceeds the ${maxWasmBytes} byte limit`,
+      { maxWasmBytes, actualBytes: wasm.length }
+    );
+  }
+}
+
+function mapRow(row) {
+  if (!row) return null;
+
+  return {
+    id: row.id,
+    contractId: row.contract_id,
+    network: row.network,
+    sourceHash: row.source_hash,
+    wasmHash: row.wasm_hash || null,
+    onChainWasmHash: row.on_chain_wasm_hash || null,
+    status: row.status,
+    verified: row.status === 'verified',
+    dependencies: parseJson(row.dependencies, {}),
+    metadata: parseJson(row.metadata, {}),
+    error: row.error_message
+      ? {
+          code: row.error_code || 'VERIFICATION_FAILED',
+          message: row.error_message,
+        }
+      : null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    verifiedAt: row.verified_at || null,
+  };
+}
+
+function publicRecord(record) {
+  return clone(record);
+}
+
+function getRpcUrl(network) {
+  const envKey = `${String(network)
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, '_')}_RPC_URL`;
+  return process.env[envKey] || process.env.SOROBAN_RPC_URL || DEFAULT_RPC_URL;
+}
+
+function errorDetails(error) {
+  return {
+    code: error?.code || 'VERIFICATION_FAILED',
+    message: error?.message || 'Contract verification failed',
+  };
+}
+
+export class VerifyService {
+  constructor(options = {}) {
+    this.db = options.db || new DatabaseService();
+    this.compile = options.compile || compileQueued;
+    this.rpcClientFactory = options.rpcClientFactory;
+    this.fetchOnChainWasm = options.fetchOnChainWasm;
+    this.readFile = options.readFile || fs.readFile;
+    this.now = options.now || nowIso;
+    this.maxSourceBytes =
+      options.maxSourceBytes ||
+      Number.parseInt(
+        process.env.VERIFICATION_MAX_SOURCE_BYTES ||
+          `${DEFAULT_MAX_SOURCE_BYTES}`,
+        10
+      );
+    this.maxWasmBytes =
+      options.maxWasmBytes ||
+      Number.parseInt(
+        process.env.VERIFICATION_MAX_WASM_BYTES || `${DEFAULT_MAX_WASM_BYTES}`,
+        10
+      );
+    this.tableReady = null;
+  }
+
+  async ensureTable() {
+    if (!this.tableReady) {
+      this.tableReady = (async () => {
+        await this.db.connect();
+        await this.db.run(CREATE_TABLE_SQL);
+        await this.db.run(
+          `CREATE INDEX IF NOT EXISTS idx_contract_verification_contract
+           ON ${TABLE_NAME} (contract_id, network, updated_at)`
+        );
+        await this.db.run(
+          `CREATE INDEX IF NOT EXISTS idx_contract_verification_status
+           ON ${TABLE_NAME} (status, updated_at)`
+        );
+      })().catch((error) => {
+        this.tableReady = null;
+        throw new VerificationError(
+          500,
+          'DATABASE_ERROR',
+          `Failed to initialize verification storage: ${error.message}`
+        );
+      });
+    }
+    await this.tableReady;
+  }
+
+  async insertPending(record) {
+    await this.db.run(
+      `INSERT INTO ${TABLE_NAME}
+       (id, contract_id, network, source_code, source_hash, dependencies, metadata,
+        status, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        record.id,
+        record.contractId,
+        record.network,
+        record.sourceCode,
+        record.sourceHash,
+        JSON.stringify(record.dependencies),
+        JSON.stringify(record.metadata),
+        'pending',
+        record.createdAt,
+        record.createdAt,
+      ]
+    );
+  }
+
+  async updateResult(id, result) {
+    await this.db.run(
+      `UPDATE ${TABLE_NAME}
+       SET wasm_hash = ?, on_chain_wasm_hash = ?, status = ?, error_code = ?,
+           error_message = ?, updated_at = ?, verified_at = ?
+       WHERE id = ?`,
+      [
+        result.wasmHash || null,
+        result.onChainWasmHash || null,
+        result.status,
+        result.error?.code || null,
+        result.error?.message || null,
+        result.updatedAt,
+        result.verifiedAt || null,
+        id,
+      ]
+    );
+  }
+
+  async loadRow(id) {
+    const row = await this.db.get(`SELECT * FROM ${TABLE_NAME} WHERE id = ?`, [
+      id,
+    ]);
+    if (!row) {
+      throw new VerificationError(
+        404,
+        'VERIFICATION_NOT_FOUND',
+        'Verification record not found'
+      );
+    }
+    return row;
+  }
+
+  async readWasm(input) {
+    if (input.wasmBase64 !== undefined) {
+      if (typeof input.wasmBase64 !== 'string' || !input.wasmBase64.trim()) {
+        throw new VerificationError(
+          400,
+          'INVALID_WASM',
+          'wasmBase64 must be a non-empty base64 string'
+        );
+      }
+      const encoded = input.wasmBase64.trim();
+      if (
+        !/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(
+          encoded
+        )
+      ) {
+        throw new VerificationError(
+          400,
+          'INVALID_WASM',
+          'wasmBase64 is not valid base64'
+        );
+      }
+      const wasm = Buffer.from(encoded, 'base64');
+      if (wasm.toString('base64') !== encoded || wasm.length === 0) {
+        throw new VerificationError(
+          400,
+          'INVALID_WASM',
+          'wasmBase64 must contain at least one byte'
+        );
+      }
+      return wasm;
+    }
+
+    if (input.wasmPath !== undefined) {
+      if (typeof input.wasmPath !== 'string' || !input.wasmPath.trim()) {
+        throw new VerificationError(
+          400,
+          'INVALID_WASM_PATH',
+          'wasmPath must be a non-empty string'
+        );
+      }
+      const wasmPath = path.resolve(input.wasmPath);
+      const allowedRoot = path.resolve(
+        process.env.VERIFICATION_ARTIFACT_ROOT || process.cwd()
+      );
+      const relative = path.relative(allowedRoot, wasmPath);
+      if (relative.startsWith('..') || path.isAbsolute(relative)) {
+        throw new VerificationError(
+          400,
+          'INVALID_WASM_PATH',
+          'wasmPath must be inside the configured artifact directory'
+        );
+      }
+      return this.readFile(wasmPath);
+    }
+
+    return null;
+  }
+
+  async getOnChainWasm(contractId, network) {
+    if (this.fetchOnChainWasm) {
+      return this.fetchOnChainWasm(contractId, network);
+    }
+
+    const client = this.rpcClientFactory
+      ? await this.rpcClientFactory(network)
+      : new SorobanRpc.Server(getRpcUrl(network));
+
+    if (typeof client?.getContractWasmByContractId !== 'function') {
+      throw new VerificationError(
+        502,
+        'RPC_UNSUPPORTED',
+        'Configured Soroban RPC client cannot retrieve contract WASM'
+      );
+    }
+
+    try {
+      return await client.getContractWasmByContractId(contractId);
+    } catch (error) {
+      throw new VerificationError(
+        502,
+        'RPC_ERROR',
+        `Failed to retrieve on-chain contract WASM: ${error.message}`
+      );
+    }
+  }
+
+  async verifyCompiledWasm({
+    contractId,
+    network,
+    sourceCode,
+    dependencies,
+    metadata,
+    wasm,
+  }) {
+    let compiledWasm = wasm;
+    let compileLogs = [];
+
+    if (!compiledWasm) {
+      let compileResult;
+      try {
+        compileResult = await this.compile({
+          requestId: `verify-${Date.now()}`,
+          code: sourceCode,
+          dependencies,
+        });
+      } catch (error) {
+        throw new VerificationError(
+          422,
+          'COMPILATION_FAILED',
+          `Source compilation failed: ${error.message}`
+        );
+      }
+
+      if (!compileResult?.success || !compileResult.artifact?.path) {
+        throw new VerificationError(
+          422,
+          'COMPILATION_FAILED',
+          compileResult?.logs?.join('\n') || 'Source compilation failed'
+        );
+      }
+
+      compileLogs = compileResult.logs || [];
+      compiledWasm = await this.readFile(compileResult.artifact.path);
+    }
+
+    validateWasmSize(compiledWasm, this.maxWasmBytes);
+    const wasmHash = hashWasm(compiledWasm);
+    const onChainWasm = await this.getOnChainWasm(contractId, network);
+    validateWasmSize(onChainWasm, this.maxWasmBytes);
+    const onChainWasmHash = hashWasm(onChainWasm);
+    const verified = wasmHash === onChainWasmHash;
+
+    return {
+      wasmHash,
+      onChainWasmHash,
+      status: verified ? 'verified' : 'mismatch',
+      verifiedAt: verified ? this.now() : null,
+      compileLogs,
+      metadata,
+    };
+  }
+
+  async verifyContract(input = {}) {
+    const contractId = validateContractId(input.contractId);
+    const network = input.network || DEFAULT_NETWORK;
+    if (typeof network !== 'string' || !/^[a-z0-9_-]{1,32}$/i.test(network)) {
+      throw new VerificationError(
+        400,
+        'INVALID_NETWORK',
+        'network must be a short alphanumeric network name'
+      );
+    }
+
+    const sourceCode = input.sourceCode ?? input.source ?? input.code;
+    validateSource(sourceCode, this.maxSourceBytes);
+    const dependencyValidation = sanitizeDependenciesInput(input.dependencies);
+    if (!dependencyValidation.ok) {
+      throw new VerificationError(
+        400,
+        'INVALID_DEPENDENCIES',
+        dependencyValidation.error,
+        dependencyValidation.details
+      );
+    }
+    const dependencies = dependencyValidation.deps;
+    const metadata = input.metadata || {};
+    validatePlainObject(metadata, 'metadata');
+
+    const providedWasm = await this.readWasm(input);
+    if (!providedWasm && !this.compile) {
+      throw new VerificationError(
+        500,
+        'COMPILER_UNAVAILABLE',
+        'No compiler is configured for source verification'
+      );
+    }
+
+    await this.ensureTable();
+
+    const timestamp = this.now();
+    const record = {
+      id: input.id || crypto.randomUUID(),
+      contractId,
+      network,
+      sourceCode,
+      sourceHash: hashSource(sourceCode),
+      dependencies,
+      metadata,
+      createdAt: timestamp,
+    };
+
+    let existingRow = null;
+    if (input.id) {
+      try {
+        existingRow = await this.loadRow(input.id);
+      } catch (error) {
+        if (
+          !(error instanceof VerificationError) ||
+          error.code !== 'VERIFICATION_NOT_FOUND'
+        ) {
+          throw error;
+        }
+      }
+    }
+
+    if (existingRow) {
+      await this.db.run(
+        `UPDATE ${TABLE_NAME}
+         SET contract_id = ?, network = ?, source_code = ?, source_hash = ?,
+             dependencies = ?, metadata = ?, status = 'pending', error_code = NULL,
+             error_message = NULL, updated_at = ?, verified_at = NULL
+         WHERE id = ?`,
+        [
+          contractId,
+          network,
+          sourceCode,
+          record.sourceHash,
+          JSON.stringify(dependencies),
+          JSON.stringify(metadata),
+          timestamp,
+          input.id,
+        ]
+      );
+      record.createdAt = existingRow.created_at;
+    } else {
+      await this.insertPending(record);
+    }
+
+    try {
+      const result = await this.verifyCompiledWasm({
+        contractId,
+        network,
+        sourceCode,
+        dependencies,
+        metadata,
+        wasm: providedWasm,
+      });
+      const updatedAt = this.now();
+      await this.updateResult(record.id, { ...result, updatedAt });
+      const responseRecord = publicRecord(record);
+      delete responseRecord.sourceCode;
+      return {
+        ...responseRecord,
+        ...result,
+        updatedAt,
+        verified: result.status === 'verified',
+      };
+    } catch (error) {
+      const failure = errorDetails(error);
+      const updatedAt = this.now();
+      await this.updateResult(record.id, {
+        status: 'failed',
+        error: failure,
+        updatedAt,
+      });
+      if (error instanceof VerificationError) throw error;
+      throw new VerificationError(502, failure.code, failure.message);
+    }
+  }
+
+  async submitVerification(input) {
+    // Record IDs are owned by the service; only the explicit reverify operation
+    // may update an existing record.
+    const { id: _ignoredId, ...submission } = input || {};
+    return this.verifyContract(submission);
+  }
+
+  async reverifyContract(id, overrides = {}) {
+    if (typeof id !== 'string' || !id.trim()) {
+      throw new VerificationError(
+        400,
+        'INVALID_ID',
+        'verification id is required'
+      );
+    }
+    await this.ensureTable();
+    const row = await this.loadRow(id);
+    return this.verifyContract({
+      id,
+      contractId: overrides.contractId || row.contract_id,
+      network: overrides.network || row.network,
+      sourceCode: overrides.sourceCode || row.source_code,
+      dependencies: overrides.dependencies || parseJson(row.dependencies, {}),
+      metadata: overrides.metadata || parseJson(row.metadata, {}),
+      wasmBase64: overrides.wasmBase64,
+      wasmPath: overrides.wasmPath,
+    });
+  }
+
+  async getVerification(id) {
+    await this.ensureTable();
+    return publicRecord(mapRow(await this.loadRow(id)));
+  }
+
+  async getSource(id) {
+    await this.ensureTable();
+    const row = await this.loadRow(id);
+    if (row.status !== 'verified') {
+      throw new VerificationError(
+        409,
+        'SOURCE_NOT_VERIFIED',
+        'Source is only available after successful bytecode verification'
+      );
+    }
+    return {
+      id: row.id,
+      contractId: row.contract_id,
+      network: row.network,
+      sourceCode: row.source_code,
+      sourceHash: row.source_hash,
+      dependencies: parseJson(row.dependencies, {}),
+      metadata: parseJson(row.metadata, {}),
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  async searchVerifications(filters = {}) {
+    await this.ensureTable();
+    const conditions = [];
+    const params = [];
+
+    if (filters.contractId) {
+      validateContractId(filters.contractId);
+      conditions.push('contract_id = ?');
+      params.push(filters.contractId);
+    }
+    if (filters.network) {
+      conditions.push('network = ?');
+      params.push(filters.network);
+    }
+    if (filters.status) {
+      if (
+        !['pending', 'verified', 'mismatch', 'failed'].includes(filters.status)
+      ) {
+        throw new VerificationError(400, 'INVALID_STATUS', 'status is invalid');
+      }
+      conditions.push('status = ?');
+      params.push(filters.status);
+    }
+
+    const parsedLimit = Number.parseInt(filters.limit ?? '20', 10);
+    const parsedOffset = Number.parseInt(filters.offset ?? '0', 10);
+    const limit = Number.isInteger(parsedLimit)
+      ? Math.min(100, Math.max(1, parsedLimit))
+      : 20;
+    const offset = Number.isInteger(parsedOffset)
+      ? Math.max(0, parsedOffset)
+      : 0;
+    const where = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+
+    const [rows, count] = await Promise.all([
+      this.db.all(
+        `SELECT * FROM ${TABLE_NAME} ${where}
+         ORDER BY updated_at DESC LIMIT ? OFFSET ?`,
+        [...params, limit, offset]
+      ),
+      this.db.get(
+        `SELECT COUNT(*) AS total FROM ${TABLE_NAME} ${where}`,
+        params
+      ),
+    ]);
+
+    return {
+      records: rows.map((row) => publicRecord(mapRow(row))),
+      total: count?.total || 0,
+      limit,
+      offset,
+    };
+  }
+}
+
+const verifyService = new VerifyService();
+export default verifyService;

--- a/backend/tests/verificationRoutes.test.js
+++ b/backend/tests/verificationRoutes.test.js
@@ -1,0 +1,157 @@
+import { jest } from '@jest/globals';
+import express from 'express';
+
+jest.mock('../src/services/compileService.js', () => ({
+  compileQueued: jest.fn(),
+}));
+
+jest.mock('../src/middleware/rateLimiter.js', () => ({
+  rateLimitMiddleware: () => (_req, _res, next) => next(),
+}));
+import request from 'supertest';
+import { StrKey } from '@stellar/stellar-sdk';
+import verifyService from '../src/services/verifyService.js';
+import verificationRouter from '../src/routes/verification.js';
+import { errorHandler } from '../src/middleware/errorHandler.js';
+
+const app = express();
+app.use(express.json());
+app.use('/api/verify', verificationRouter);
+app.use(errorHandler);
+
+const CONTRACT_ID = StrKey.encodeContract(Buffer.alloc(32, 2));
+const WASM = Buffer.from([0, 97, 115, 109, 1, 0, 0, 0]);
+
+const originalMethods = {};
+
+beforeEach(() => {
+  for (const method of [
+    'submitVerification',
+    'getVerification',
+    'getSource',
+    'reverifyContract',
+    'searchVerifications',
+  ]) {
+    originalMethods[method] = verifyService[method];
+  }
+});
+
+afterEach(() => {
+  for (const [method, implementation] of Object.entries(originalMethods)) {
+    verifyService[method] = implementation;
+  }
+});
+
+describe('contract verification routes', () => {
+  it('returns 200 for an exact match', async () => {
+    verifyService.submitVerification = async () => ({
+      id: 'verified-1',
+      status: 'verified',
+      verified: true,
+      contractId: CONTRACT_ID,
+    });
+
+    const response = await request(app)
+      .post('/api/verify/contracts')
+      .send({ contractId: CONTRACT_ID, sourceCode: 'pub fn contract() {}' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toMatchObject({
+      success: true,
+      data: { id: 'verified-1', status: 'verified' },
+    });
+  });
+
+  it('returns 202 for a completed mismatch', async () => {
+    verifyService.submitVerification = async () => ({
+      id: 'mismatch-1',
+      status: 'mismatch',
+      verified: false,
+      contractId: CONTRACT_ID,
+    });
+
+    const response = await request(app)
+      .post('/api/verify/contracts')
+      .send({ contractId: CONTRACT_ID, sourceCode: 'pub fn contract() {}' });
+
+    expect(response.status).toBe(202);
+    expect(response.body).toMatchObject({
+      success: false,
+      data: { status: 'mismatch' },
+    });
+  });
+
+  it('routes /search before the dynamic id route', async () => {
+    verifyService.searchVerifications = async () => ({
+      records: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+    });
+
+    const response = await request(app).get('/api/verify/contracts/search');
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toMatchObject({ total: 0, records: [] });
+  });
+
+  it('maps service errors to the shared error response', async () => {
+    verifyService.submitVerification = async () => {
+      const error = new Error('bad source');
+      error.statusCode = 422;
+      error.code = 'COMPILATION_FAILED';
+      throw error;
+    };
+
+    const response = await request(app)
+      .post('/api/verify/contracts')
+      .send({ contractId: CONTRACT_ID, sourceCode: 'invalid' });
+
+    expect(response.status).toBe(422);
+    expect(response.body).toMatchObject({
+      statusCode: 422,
+      message: 'bad source',
+    });
+  });
+
+  it('supports status and source endpoints through the service adapter', async () => {
+    verifyService.getVerification = async (id) => ({
+      id,
+      status: 'verified',
+      verified: true,
+    });
+    verifyService.getSource = async (id) => ({
+      id,
+      sourceCode: 'pub fn contract() {}',
+    });
+
+    const statusResponse = await request(app).get(
+      '/api/verify/contracts/verified-1'
+    );
+    const sourceResponse = await request(app).get(
+      '/api/verify/contracts/verified-1/source'
+    );
+
+    expect(statusResponse.status).toBe(200);
+    expect(sourceResponse.status).toBe(200);
+    expect(sourceResponse.body.data.sourceCode).toBe('pub fn contract() {}');
+  });
+
+  it('supports re-verification through the service adapter', async () => {
+    verifyService.reverifyContract = async (id) => ({
+      id,
+      status: 'verified',
+      verified: true,
+    });
+
+    const response = await request(app)
+      .post('/api/verify/contracts/verified-1/reverify')
+      .send({ wasmBase64: WASM.toString('base64') });
+
+    expect(response.status).toBe(200);
+    expect(response.body.data).toMatchObject({
+      id: 'verified-1',
+      status: 'verified',
+    });
+  });
+});

--- a/backend/tests/verifyService.test.js
+++ b/backend/tests/verifyService.test.js
@@ -1,0 +1,295 @@
+import { jest } from '@jest/globals';
+import { StrKey } from '@stellar/stellar-sdk';
+
+jest.mock('../src/services/compileService.js', () => ({
+  compileQueued: jest.fn(),
+}));
+
+function makeDb() {
+  const rows = new Map();
+  return {
+    rows,
+    async connect() {},
+    async run(sql, params = []) {
+      if (sql.includes('INSERT INTO contract_verification')) {
+        rows.set(params[0], {
+          id: params[0],
+          contract_id: params[1],
+          network: params[2],
+          source_code: params[3],
+          source_hash: params[4],
+          dependencies: params[5],
+          metadata: params[6],
+          status: params[7],
+          created_at: params[8],
+          updated_at: params[9],
+          wasm_hash: null,
+          on_chain_wasm_hash: null,
+          error_code: null,
+          error_message: null,
+          verified_at: null,
+        });
+      } else if (sql.includes('UPDATE contract_verification')) {
+        const id = params[params.length - 1];
+        const row = rows.get(id);
+        if (sql.includes("status = 'pending'")) {
+          Object.assign(row, {
+            contract_id: params[0],
+            network: params[1],
+            source_code: params[2],
+            source_hash: params[3],
+            dependencies: params[4],
+            metadata: params[5],
+            status: 'pending',
+            error_code: null,
+            error_message: null,
+            updated_at: params[6],
+            verified_at: null,
+          });
+        } else {
+          Object.assign(row, {
+            wasm_hash: params[0],
+            on_chain_wasm_hash: params[1],
+            status: params[2],
+            error_code: params[3],
+            error_message: params[4],
+            updated_at: params[5],
+            verified_at: params[6],
+          });
+        }
+      }
+    },
+    async get(sql, params = []) {
+      if (sql.includes('SELECT * FROM contract_verification')) {
+        return rows.get(params[0]) || null;
+      }
+      if (sql.includes('COUNT(*)')) return { total: rows.size };
+      return null;
+    },
+    async all() {
+      return [...rows.values()];
+    },
+  };
+}
+
+const {
+  VerifyService,
+  VerificationError,
+  hashWasm,
+  hashSource,
+} = require('../src/services/verifyService.js');
+
+const CONTRACT_ID = StrKey.encodeContract(Buffer.alloc(32, 1));
+const SOURCE = '#![no_std]\npub fn contract() {}';
+const WASM = Buffer.from([0, 97, 115, 109, 1, 0, 0, 0]);
+
+function createService(onChainWasm = WASM) {
+  const db = makeDb();
+  const service = new VerifyService({
+    db,
+    compile: jest.fn(),
+    fetchOnChainWasm: jest.fn().mockResolvedValue(onChainWasm),
+    now: jest.fn().mockReturnValue('2026-08-26T00:00:00.000Z'),
+  });
+  return { service, db };
+}
+
+describe('VerifyService', () => {
+  it('hashes exact WASM bytes and reports a verified match', async () => {
+    const { service } = createService();
+    const result = await service.verifyContract({
+      id: 'verification-1',
+      contractId: CONTRACT_ID,
+      sourceCode: SOURCE,
+      wasmBase64: WASM.toString('base64'),
+    });
+
+    expect(result.status).toBe('verified');
+    expect(result.verified).toBe(true);
+    expect(result.wasmHash).toBe(hashWasm(WASM));
+    expect(result.onChainWasmHash).toBe(hashWasm(WASM));
+    expect(result.sourceHash).toBe(hashSource(SOURCE));
+  });
+
+  it('records a mismatch when compiled bytes differ from on-chain bytes', async () => {
+    const { service } = createService(Buffer.concat([WASM, Buffer.from([1])]));
+    const result = await service.verifyContract({
+      contractId: CONTRACT_ID,
+      sourceCode: SOURCE,
+      wasmBase64: WASM.toString('base64'),
+    });
+
+    expect(result.status).toBe('mismatch');
+    expect(result.verified).toBe(false);
+    expect(result.wasmHash).not.toBe(result.onChainWasmHash);
+  });
+
+  it('compiles source when no WASM artifact is supplied', async () => {
+    const { service } = createService();
+    service.compile.mockResolvedValue({
+      success: true,
+      logs: ['compiled'],
+      artifact: { path: '/tmp/contract.wasm' },
+    });
+    service.readFile = jest.fn().mockResolvedValue(WASM);
+
+    const result = await service.verifyContract({
+      contractId: CONTRACT_ID,
+      sourceCode: SOURCE,
+      dependencies: { 'serde-json': '^1.0' },
+    });
+
+    expect(service.compile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: SOURCE,
+        dependencies: { 'serde-json': '^1.0' },
+      })
+    );
+    expect(result.status).toBe('verified');
+  });
+
+  it('rejects dependency input that is not safe for Cargo generation', async () => {
+    const { service } = createService();
+
+    await expect(
+      service.verifyContract({
+        contractId: CONTRACT_ID,
+        sourceCode: SOURCE,
+        dependencies: { 'bad-name': '1.0\nmalicious = true' },
+      })
+    ).rejects.toMatchObject({
+      code: 'INVALID_DEPENDENCIES',
+      statusCode: 400,
+    });
+  });
+
+  it('persists a failed status when source compilation fails', async () => {
+    const { service, db } = createService();
+    service.compile.mockRejectedValue(new Error('cargo: syntax error'));
+
+    await expect(
+      service.verifyContract({
+        id: 'failed-1',
+        contractId: CONTRACT_ID,
+        sourceCode: SOURCE,
+      })
+    ).rejects.toMatchObject({
+      code: 'COMPILATION_FAILED',
+      statusCode: 422,
+    });
+
+    expect(db.rows.get('failed-1')).toMatchObject({
+      status: 'failed',
+      error_code: 'COMPILATION_FAILED',
+    });
+  });
+
+  it('rejects malformed contract IDs, source, and oversized input', async () => {
+    const { service } = createService();
+
+    await expect(
+      service.verifyContract({
+        contractId: 'not-a-contract',
+        sourceCode: SOURCE,
+      })
+    ).rejects.toMatchObject({ code: 'INVALID_CONTRACT_ID', statusCode: 400 });
+
+    await expect(
+      service.verifyContract({ contractId: CONTRACT_ID, sourceCode: ' ' })
+    ).rejects.toMatchObject({ code: 'INVALID_SOURCE', statusCode: 400 });
+
+    const smallService = new VerifyService({
+      db: makeDb(),
+      maxSourceBytes: 3,
+      compile: jest.fn(),
+    });
+    await expect(
+      smallService.verifyContract({
+        contractId: CONTRACT_ID,
+        sourceCode: 'abcd',
+      })
+    ).rejects.toMatchObject({ code: 'SOURCE_TOO_LARGE', statusCode: 413 });
+  });
+
+  it('does not expose source code in status records or search results', async () => {
+    const { service } = createService();
+    const result = await service.verifyContract({
+      id: 'privacy-1',
+      contractId: CONTRACT_ID,
+      sourceCode: SOURCE,
+      wasmBase64: WASM.toString('base64'),
+    });
+    const status = await service.getVerification(result.id);
+    const search = await service.searchVerifications();
+
+    expect(status).not.toHaveProperty('sourceCode');
+    expect(search.records[0]).not.toHaveProperty('sourceCode');
+    await expect(service.getSource(result.id)).resolves.toMatchObject({
+      sourceCode: SOURCE,
+    });
+  });
+
+  it('does not expose source for a mismatched verification', async () => {
+    const { service } = createService(Buffer.concat([WASM, Buffer.from([1])]));
+    const result = await service.verifyContract({
+      contractId: CONTRACT_ID,
+      sourceCode: SOURCE,
+      wasmBase64: WASM.toString('base64'),
+    });
+
+    await expect(service.getSource(result.id)).rejects.toMatchObject({
+      code: 'SOURCE_NOT_VERIFIED',
+      statusCode: 409,
+    });
+  });
+
+  it('does not allow a submission to overwrite an existing record id', async () => {
+    const { service, db } = createService();
+    const first = await service.verifyContract({
+      id: 'owned-id',
+      contractId: CONTRACT_ID,
+      sourceCode: SOURCE,
+      wasmBase64: WASM.toString('base64'),
+    });
+    const second = await service.submitVerification({
+      id: first.id,
+      contractId: CONTRACT_ID,
+      sourceCode: `${SOURCE}\n// changed`,
+      wasmBase64: WASM.toString('base64'),
+    });
+
+    expect(second.id).not.toBe(first.id);
+    expect(db.rows.has(second.id)).toBe(true);
+  });
+
+  it('uses the SDK-compatible RPC client when no custom fetcher is supplied', async () => {
+    const db = makeDb();
+    const getContractWasmByContractId = jest.fn().mockResolvedValue(WASM);
+    const rpcClientFactory = jest.fn().mockResolvedValue({
+      getContractWasmByContractId,
+    });
+    const service = new VerifyService({
+      db,
+      rpcClientFactory,
+      compile: jest.fn().mockResolvedValue({
+        success: true,
+        artifact: { path: '/tmp/contract.wasm' },
+      }),
+      readFile: jest.fn().mockResolvedValue(WASM),
+    });
+
+    await service.verifyContract({
+      contractId: CONTRACT_ID,
+      sourceCode: SOURCE,
+    });
+
+    expect(rpcClientFactory).toHaveBeenCalledWith('testnet');
+    expect(getContractWasmByContractId).toHaveBeenCalledWith(CONTRACT_ID);
+  });
+});
+
+describe('hash helpers', () => {
+  it('rejects non-binary WASM values', () => {
+    expect(() => hashWasm('wasm')).toThrow(VerificationError);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Implements production-grade Soroban contract source verification and exact bytecode hash matching for issue #1292.

- Adds `backend/src/services/verifyService.js` with:
  - SHA-256 hashing of source and exact WASM bytes
  - checksummed Stellar contract ID validation
  - existing compiler integration with shared dependency sanitization
  - Soroban RPC retrieval via `getContractWasmByContractId`
  - verified, mismatch, pending, and failed outcomes
  - bounded source/WASM input and safe artifact path handling
  - durable SQLite-compatible persistence with injectable adapters
- Adds `/api/verify/contracts` REST endpoints for submit, status, source, reverify, and search.
- Adds migration, OpenAPI docs, README/env documentation, and comprehensive service/HTTP tests.
- Status and search responses do not expose source; source retrieval requires a successful verification.

## Related Issue

Closes #1292

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor / Code improvement

## Affected Areas

- [x] backend/
- [x] Documentation / README

## Testing

- `npm exec -- jest tests/verifyService.test.js --runInBand` — 11 passed
- `npm exec -- jest tests/verificationRoutes.test.js --runInBand` — 6 passed
- `npm exec -- jest tests/compile.test.js tests/swagger.test.js tests/migration.test.js --runInBand` — 37 passed
- Prettier checks passed for all changed JavaScript/Markdown files.
- Node syntax checks and `git diff --check` passed.
- Full backend build is currently blocked by the repository environment missing the existing `typescript` package required by ESLint; no source lint result was produced.

## Notes

The pre-existing working-tree change to `package-lock.json` was intentionally left out of this commit.